### PR TITLE
Fixes issue that RunProxy doesn't respect mapped routes

### DIFF
--- a/src/ProxyKit.Tests/EndToEndTests.cs
+++ b/src/ProxyKit.Tests/EndToEndTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace ProxyKit
+{
+    public class EndToEndTests : IDisposable
+    {
+        private TestServer _testServer;
+
+        public EndToEndTests()
+        {
+            var webHostBuilder = new WebHostBuilder()
+                .UseStartup<TestStartup>();
+            _testServer = new TestServer(webHostBuilder);
+        }
+
+        [Fact]
+        public async Task Can_get_proxied_route()
+        {
+            var client = _testServer.CreateClient();
+            var result = await client.GetAsync("/accepted");
+            result.StatusCode.ShouldBe(HttpStatusCode.Accepted);
+
+            result = await client.GetAsync("/forbidden");
+            result.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+        }
+
+        public void Dispose()
+        {
+            _testServer?.Dispose();
+        }
+    }
+
+    public class TestStartup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddProxy(); //Required to add this.
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            // Can return the destination URI in three different ways.
+            app.RunProxy(
+                "/accepted",
+                requestContext => HttpStatusCode.Accepted);
+
+            app.RunProxy("/forbidden", requestContext => HttpStatusCode.Forbidden);
+
+        }
+    }
+}

--- a/src/ProxyKit/ApplicationBuilderExtensions.cs
+++ b/src/ProxyKit/ApplicationBuilderExtensions.cs
@@ -46,7 +46,7 @@ namespace ProxyKit
 
             app.Map(pathMatch, appInner =>
             {
-                app.UseMiddleware<ProxyMiddleware>(proxyOptions);
+                appInner.UseMiddleware<ProxyMiddleware>(proxyOptions);
             });
         }
 


### PR DESCRIPTION
When registering the following routes:

            app.RunProxy(
                "/accepted",
                requestContext => HttpStatusCode.Accepted);

            app.RunProxy("/forbidden", requestContext => HttpStatusCode.Forbidden);

it would always return "accepted", becuase it didn't use the actual subpath. With this pr it does. 

