### PR TITLE
fixes issue httpclienthandler being disposed

### DIFF
--- a/src/ProxyKit.Tests/PassthroughProxyTest.cs
+++ b/src/ProxyKit.Tests/PassthroughProxyTest.cs
@@ -36,7 +36,7 @@ namespace ProxyKit
             _builder = new WebHostBuilder()
                 .ConfigureServices(services => services.AddProxy(options =>
                 {
-                    options.MessageHandler = _testMessageHandler;
+                    options.GetMessageHandler = () => _testMessageHandler;
                 }));
         }
 

--- a/src/ProxyKit/ServiceCollectionExtensions.cs
+++ b/src/ProxyKit/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -24,10 +25,14 @@ namespace ProxyKit
 
             services.Configure(configureOptions);
 
-            services.AddHttpClient("ProxyKit")
+            var clientBuiler = services.AddHttpClient("ProxyKit")
                 .ConfigureHttpClient((sp, c) => sp.GetRequiredService<IOptions<SharedProxyOptions>>().Value.ConfigureHttpClient?.Invoke(sp, c))
+
                 .ConfigurePrimaryHttpMessageHandler(sp =>
-                    sp.GetRequiredService<IOptions<SharedProxyOptions>>().Value.MessageHandler);
+                    // Get the message handler from the options
+                    sp.GetRequiredService<IOptions<SharedProxyOptions>>().Value.GetMessageHandler?.Invoke() 
+                    // Or construct one with default settings
+                    ?? new HttpClientHandler { AllowAutoRedirect = false, UseCookies = false });
 
             return services;
         }

--- a/src/ProxyKit/SharedProxyOptions.cs
+++ b/src/ProxyKit/SharedProxyOptions.cs
@@ -12,10 +12,10 @@ namespace ProxyKit
     public class SharedProxyOptions
     {
         /// <summary>
-        /// Message handler used for http message forwarding.
+        /// Builds a message handler used for http message forwarding.
+        /// the handler can be re-created by aspnet core, so has to be a function. 
         /// </summary>
-        public HttpMessageHandler MessageHandler { get; set; } =
-            new HttpClientHandler {AllowAutoRedirect = false, UseCookies = false};
+        public Func<HttpMessageHandler> GetMessageHandler { get; set; }
 
         public Action<IServiceProvider, HttpClient> ConfigureHttpClient { get; set; }
 }


### PR DESCRIPTION
Asp.net core will periodically recycle the HttpClientHandler. The default implementation only uses a single instance, so when it get's disposed, you run into issues. 

This logic turns the MessageHandler option into a function, thus allowing aspnet to re-renerate the handlers. 