### PR TITLE
Do not copy X-Forwarded-* headers from incoming request by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,23 @@ issues making it suitable for microservice / container environments.
 
 <!-- TOC depthFrom:2 -->
 
-- [1. Quick Start](#1-quick-start)
-- [2. Customising the upstream request](#2-customising-the-upstream-request)
-- [3. Customising the upstream response](#3-customising-the-upstream-response)
-- [4. X-Forwarded Headers](#4-x-forwarded-headers)
-- [5. Making upstream servers reverse proxy friendly](#5-making-upstream-servers-reverse-proxy-friendly)
-- [6. Configuring ProxyOptions](#6-configuring-proxyoptions)
-- [7. Error handling](#7-error-handling)
-- [8. Testing](#8-testing)
-- [9. Load Balancing](#9-load-balancing)
+- [ProxyKit [![Build Status][travis build]][project] [![NuGet][nuget badge]][nuget package]](#proxykit-build-statustravis-buildproject-nugetnuget-badgenuget-package)
+  - [1. Quick Start](#1-quick-start)
+  - [2. Customising the upstream request](#2-customising-the-upstream-request)
+  - [3. Customising the upstream response](#3-customising-the-upstream-response)
+  - [4. X-Forwarded Headers](#4-x-forwarded-headers)
+  - [5. Making upstream servers reverse proxy friendly](#5-making-upstream-servers-reverse-proxy-friendly)
+  - [6. Configuring ProxyOptions](#6-configuring-proxyoptions)
+  - [7. Error handling](#7-error-handling)
+  - [8. Testing](#8-testing)
+  - [9. Load Balancing](#9-load-balancing)
     - [9.1. Weighted Round Robin](#91-weighted-round-robin)
-- [10. Recipes](#10-recipes)
-- [11. Performance considerations](#11-performance-considerations)
-- [12. Note about serverless](#12-note-about-serverless)
-- [13. Comparison with Ocelot](#13-comparison-with-ocelot)
-- [15. How to build](#15-how-to-build)
-- [14. Contributing / Feedback / Questions](#14-contributing--feedback--questions)
+  - [10. Recipes](#10-recipes)
+  - [11. Performance considerations](#11-performance-considerations)
+  - [12. Note about serverless](#12-note-about-serverless)
+  - [13. Comparison with Ocelot](#13-comparison-with-ocelot)
+  - [15. How to build](#15-how-to-build)
+  - [14. Contributing / Feedback / Questions](#14-contributing--feedback--questions)
 
 <!-- /TOC -->
 
@@ -61,7 +62,7 @@ public void Configure(IApplicationBuilder app)
 {
     app.RunProxy(context => context
         .ForwardTo("http://upstream-server:5001")
-        .Execute());
+        .Send());
 }
 ```
 
@@ -70,7 +71,7 @@ What is happening here?
  1. `context.ForwardTo(upstreamHost)` is an extension method over the
     `HttpContext` that creates and initializes an `HttpRequestMessage` with
     the original request headers copied over and returns a `ForwardContext`.
- 2. `Execute` forwards the request to the upstream server and returns an
+ 2. `Send` Sends the forward request to the upstream server and returns an
     `HttpResponseMessage`.
  3. The proxy middleware then takes the response and applies it to
     `HttpContext.Response`.
@@ -98,7 +99,7 @@ public void Configure(IApplicationBuilder app)
         {
             forwardContext.UpstreamRequest.Headers.Add(XCorrelationId, Guid.NewGuid().ToString());
         }
-        return forwardContext.Execute();
+        return forwardContext.Send();
     });
 }
 ```
@@ -127,7 +128,7 @@ public void Configure(IApplicationBuilder app)
     app.RunProxy(context => context
         .ForwardTo("http://localhost:5001")
         .ApplyCorrelationId()
-        .Execute());
+        .Send());
 }
 ```
 
@@ -143,7 +144,7 @@ client. In this example we are removing a header:
     {
         var response = await context
             .ForwardTo("http://localhost:5001")
-            .Execute();
+            .Send();
 
         response.Headers.Remove("MachineID");
 
@@ -169,7 +170,7 @@ public void Configure(IApplicationBuilder app)
     app.RunProxy(context => context
         .ForwardTo("http://upstream-server:5001")
         .ApplyXForwardedHeaders()
-        .Execute());
+        .Send());
 }
 ```
 
@@ -336,7 +337,7 @@ public void Configure(IApplicationBuilder app)
 
             return await context
                 .ForwardTo(host)
-                .Execute();
+                .Send();
         });
 }
 ```

--- a/README.md
+++ b/README.md
@@ -365,9 +365,13 @@ promoted to an out-of-the-box feature in a future version of ProxyKit.
    Really useful if your application has eventually consistent aspects.
 7. [Customise Upstream Requests](src/Recipes/07_CustomiseUpstreamRequest.cs) -
    Customise the upstream request by adding a header.
-8. [Customise Upstream Responses](src/Recipes/08_CustomiseUpstreamResponse.cs) -  Customise the upstream response by removing a header.
+8. [Customise Upstream Responses](src/Recipes/08_CustomiseUpstreamResponse.cs) -
+   Customise the upstream response by removing a header.
 9. [Consul Service Discovery](src/Recipes/09_ConsulServiceDisco.cs) - Service
    discovery for an upstream host using [Consul](https://www.consul.io/).
+10. [Copy X-Forward Headers](src/Recipes/10_CopyXForward.cs) - Copies
+    `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Proto` and
+    `X-Forwarded-PathBase` headers from the incoming request.
 
 ## 11. Performance considerations
 

--- a/src/ProxyKit.Tests/EndToEndTests.cs
+++ b/src/ProxyKit.Tests/EndToEndTests.cs
@@ -219,7 +219,7 @@ namespace ProxyKit
                 app.Map("/realServer", appInner =>
                     appInner.RunProxy(context => context
                         .ForwardTo("http://localhost:" + port + "/")
-                        .Execute()));
+                        .Send()));
             }
         }
     }

--- a/src/ProxyKit.Tests/PassthroughProxyTest.cs
+++ b/src/ProxyKit.Tests/PassthroughProxyTest.cs
@@ -51,7 +51,7 @@ namespace ProxyKit
             _builder.Configure(app => app.RunProxy((context)=>
             {
                 var forwardContext = context.ForwardTo($"http://localhost:{port}");
-                return forwardContext.Execute();
+                return forwardContext.Send();
             }));
             var server = new TestServer(_builder);
 
@@ -87,7 +87,7 @@ namespace ProxyKit
                 context => context
                     .ForwardTo($"http://localhost:{port}/foo/")
                     .ApplyXForwardedHeaders()
-                    .Execute()));
+                    .Send()));
             var server = new TestServer(_builder);
             var client = server.CreateClient();
 
@@ -117,7 +117,7 @@ namespace ProxyKit
                 context => context
                     .ForwardTo("http://localhost:5000/bar/")
                     .ApplyXForwardedHeaders()
-                    .Execute()));
+                    .Send()));
             var server = new TestServer(_builder);
             var client = server.CreateClient();
 

--- a/src/ProxyKit.Tests/PassthroughProxyTest.cs
+++ b/src/ProxyKit.Tests/PassthroughProxyTest.cs
@@ -86,7 +86,7 @@ namespace ProxyKit
             _builder.Configure(app => app.RunProxy(
                 context => context
                     .ForwardTo($"http://localhost:{port}/foo/")
-                    .ApplyXForwardedHeaders()
+                    .AddXForwardedHeaders()
                     .Send()));
             var server = new TestServer(_builder);
             var client = server.CreateClient();
@@ -116,7 +116,7 @@ namespace ProxyKit
             _builder.Configure(app => app.RunProxy(
                 context => context
                     .ForwardTo("http://localhost:5000/bar/")
-                    .ApplyXForwardedHeaders()
+                    .AddXForwardedHeaders()
                     .Send()));
             var server = new TestServer(_builder);
             var client = server.CreateClient();

--- a/src/ProxyKit/ForwardContext.cs
+++ b/src/ProxyKit/ForwardContext.cs
@@ -22,10 +22,20 @@ namespace ProxyKit
             UpstreamRequest = upstreamRequest;
         }
 
+        /// <summary>
+        /// The incoming HttpContext
+        /// </summary>
         public HttpContext HttpContext { get; }
 
+        /// <summary>
+        /// The upstream request message.
+        /// </summary>
         public HttpRequestMessage UpstreamRequest { get; }
 
+        /// <summary>
+        /// Executes the forward request.
+        /// </summary>
+        /// <returns></returns>
         public async Task<HttpResponseMessage> Execute()
         {
             try

--- a/src/ProxyKit/ForwardContext.cs
+++ b/src/ProxyKit/ForwardContext.cs
@@ -33,10 +33,17 @@ namespace ProxyKit
         public HttpRequestMessage UpstreamRequest { get; }
 
         /// <summary>
-        /// Executes the forward request.
+        /// Executes the forward request. [Obsolete. Use Send() instead. This will be removed in a future version].
         /// </summary>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> Execute()
+        [Obsolete("Use Send() instead. This will be removed in a future version", false)]
+        public Task<HttpResponseMessage> Execute() => Send();
+
+        /// <summary>
+        /// Sends the forward request to the upstream host.
+        /// </summary>
+        /// <returns>An HttpResponseMessage </returns>
+        public async Task<HttpResponseMessage> Send()
         {
             try
             {
@@ -54,7 +61,7 @@ namespace ProxyKit
                 // Happens when Timeout is low and upstream host is not reachable.
                 return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
             }
-            catch (HttpRequestException ex) 
+            catch (HttpRequestException ex)
                 when (ex.InnerException is IOException || ex.InnerException is SocketException)
             {
                 // Happens when server is not reachable

--- a/src/ProxyKit/HttpContextExtensions.cs
+++ b/src/ProxyKit/HttpContextExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 
@@ -18,9 +19,13 @@ namespace ProxyKit
                 requestMessage.Content = streamContent;
             }
 
-            // Copy the request headers
+            // Copy the request headers *except* x-forwarded-* headers.
             foreach (var header in request.Headers)
             {
+                if(header.Key.StartsWith("X-Forwarded-", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
                 if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray()))
                 {
                     requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());

--- a/src/ProxyKit/ProxyContextExtensions.cs
+++ b/src/ProxyKit/ProxyContextExtensions.cs
@@ -7,6 +7,12 @@ namespace ProxyKit
 {
     public static class ProxyContextExtensions
     {
+        /// <summary>
+        /// Forward the request to the specified upstream host.
+        /// </summary>
+        /// <param name="context">The HttpContext</param>
+        /// <param name="upstreamHost">The upstream host to forward the requests to.</param>
+        /// <returns>A <see cref="ForwardContext"/> that represents the forwarding request context.</returns>
         public static ForwardContext ForwardTo(this HttpContext context, UpstreamHost upstreamHost)
         {
             var uri = new Uri(UriHelper.BuildAbsolute(
@@ -26,7 +32,13 @@ namespace ProxyKit
 
             return new ForwardContext(context, request, proxyKitClient.Client);
         }
-
+        
+        /// <summary>
+        /// Applies X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto and X-Forwarded-PathBase headers
+        /// to the forward request context.
+        /// </summary>
+        /// <param name="forwardContext">The forward context.</param>
+        /// <returns>The forward context.</returns>
         public static ForwardContext ApplyXForwardedHeaders(this ForwardContext forwardContext)
         {
             var headers = forwardContext.UpstreamRequest.Headers;

--- a/src/ProxyKit/ProxyContextExtensions.cs
+++ b/src/ProxyKit/ProxyContextExtensions.cs
@@ -34,15 +34,28 @@ namespace ProxyKit
 
             return new ForwardContext(context, request, proxyKitClient.Client);
         }
-        
+
         /// <summary>
         ///     Applies X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto and
         ///     X-Forwarded-PathBase headers to the forward request context. If
-        ///     the headers already exist, they will be appended.
+        ///     the headers already exist, they will be appended, otherwise they
+        ///     will be added.
         /// </summary>
         /// <param name="forwardContext">The forward context.</param>
         /// <returns>The forward context.</returns>
-        public static ForwardContext ApplyXForwardedHeaders(this ForwardContext forwardContext)
+        [Obsolete("Use AddXForwardHeaders() instead. This will be removed in a future version", false)]
+        public static ForwardContext ApplyXForwardedHeaders(this ForwardContext forwardContext) =>
+            forwardContext.AddXForwardHeaders();
+
+        /// <summary>
+        ///     Adds X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto and
+        ///     X-Forwarded-PathBase headers to the forward request context. If
+        ///     the headers already exist they will be appended otherwise they
+        ///     will be added.
+        /// </summary>
+        /// <param name="forwardContext">The forward context.</param>
+        /// <returns>The forward context.</returns>
+        public static ForwardContext AddXForwardHeaders(this ForwardContext forwardContext)
         {
             var headers = forwardContext.UpstreamRequest.Headers;
             var protocol = forwardContext.HttpContext.Request.Scheme;

--- a/src/ProxyKit/ProxyContextExtensions.cs
+++ b/src/ProxyKit/ProxyContextExtensions.cs
@@ -8,11 +8,13 @@ namespace ProxyKit
     public static class ProxyContextExtensions
     {
         /// <summary>
-        /// Forward the request to the specified upstream host.
+        ///     Forward the request to the specified upstream host.
         /// </summary>
         /// <param name="context">The HttpContext</param>
-        /// <param name="upstreamHost">The upstream host to forward the requests to.</param>
-        /// <returns>A <see cref="ForwardContext"/> that represents the forwarding request context.</returns>
+        /// <param name="upstreamHost">The upstream host to forward the requests
+        /// to.</param>
+        /// <returns>A <see cref="ForwardContext"/> that represents the
+        /// forwarding request context.</returns>
         public static ForwardContext ForwardTo(this HttpContext context, UpstreamHost upstreamHost)
         {
             var uri = new Uri(UriHelper.BuildAbsolute(
@@ -34,8 +36,9 @@ namespace ProxyKit
         }
         
         /// <summary>
-        /// Applies X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto and X-Forwarded-PathBase headers
-        /// to the forward request context.
+        ///     Applies X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto and
+        ///     X-Forwarded-PathBase headers to the forward request context. If
+        ///     the headers already exist, they will be appended.
         /// </summary>
         /// <param name="forwardContext">The forward context.</param>
         /// <returns>The forward context.</returns>
@@ -49,6 +52,45 @@ namespace ProxyKit
             var pathBase = forwardContext.HttpContext.Request.PathBase.Value;
 
             headers.ApplyXForwardedHeaders(@for, hostString, protocol, pathBase);
+
+            return forwardContext;
+        }
+
+        /// <summary>
+        ///     Copies X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto and
+        ///     X-Forwarded-PathBase headers to the forward request context from
+        ///     the incoming request. This should only be performed if this. If
+        ///     the headers already exist, they will be appended.
+        /// </summary>
+        /// <param name="forwardContext">The forward context.</param>
+        /// <returns>The forward context.</returns>
+        public static ForwardContext CopyXForwardedHeaders(this ForwardContext forwardContext)
+        {
+            var headers = forwardContext.UpstreamRequest.Headers;
+
+            if (forwardContext.HttpContext.Request.Headers.TryGetValue(XForwardedExtensions.XForwardedFor, out var forValues))
+            {
+                headers.Remove(XForwardedExtensions.XForwardedFor);
+                headers.TryAddWithoutValidation(XForwardedExtensions.XForwardedFor, forValues.ToArray());
+            }
+
+            if (forwardContext.HttpContext.Request.Headers.TryGetValue(XForwardedExtensions.XForwardedHost, out var hostValues))
+            {
+                headers.Remove(XForwardedExtensions.XForwardedHost);
+                headers.TryAddWithoutValidation(XForwardedExtensions.XForwardedHost, hostValues.ToArray());
+            }
+
+            if (forwardContext.HttpContext.Request.Headers.TryGetValue(XForwardedExtensions.XForwardedProto, out var protoValues))
+            {
+                headers.Remove(XForwardedExtensions.XForwardedProto);
+                headers.TryAddWithoutValidation(XForwardedExtensions.XForwardedProto, protoValues.ToArray());
+            }
+
+            if (forwardContext.HttpContext.Request.Headers.TryGetValue(XForwardedExtensions.XForwardedPathBase, out var pathBaseValues))
+            {
+                headers.Remove(XForwardedExtensions.XForwardedPathBase);
+                headers.TryAddWithoutValidation(XForwardedExtensions.XForwardedPathBase, pathBaseValues.ToArray());
+            }
 
             return forwardContext;
         }

--- a/src/ProxyKit/ProxyContextExtensions.cs
+++ b/src/ProxyKit/ProxyContextExtensions.cs
@@ -43,9 +43,9 @@ namespace ProxyKit
         /// </summary>
         /// <param name="forwardContext">The forward context.</param>
         /// <returns>The forward context.</returns>
-        [Obsolete("Use AddXForwardHeaders() instead. This will be removed in a future version", false)]
+        [Obsolete("Use AddXForwardedHeaders() instead. This will be removed in a future version", false)]
         public static ForwardContext ApplyXForwardedHeaders(this ForwardContext forwardContext) =>
-            forwardContext.AddXForwardHeaders();
+            forwardContext.AddXForwardedHeaders();
 
         /// <summary>
         ///     Adds X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto and
@@ -55,7 +55,7 @@ namespace ProxyKit
         /// </summary>
         /// <param name="forwardContext">The forward context.</param>
         /// <returns>The forward context.</returns>
-        public static ForwardContext AddXForwardHeaders(this ForwardContext forwardContext)
+        public static ForwardContext AddXForwardedHeaders(this ForwardContext forwardContext)
         {
             var headers = forwardContext.UpstreamRequest.Headers;
             var protocol = forwardContext.HttpContext.Request.Scheme;

--- a/src/ProxyKit/ProxyKitClient.cs
+++ b/src/ProxyKit/ProxyKitClient.cs
@@ -2,7 +2,7 @@
 
 namespace ProxyKit
 {
-    internal class ProxyKitClient
+    public class ProxyKitClient
     {
         internal HttpClient Client { get; }
 

--- a/src/Recipes/01_Simple.cs
+++ b/src/Recipes/01_Simple.cs
@@ -17,7 +17,7 @@ namespace ProxyKit.Recipes
                 app.RunProxy(context => context
                     .ForwardTo("http://localhost:5001")
                     .ApplyXForwardedHeaders()
-                    .Execute());
+                    .Send());
             }
         }
     }

--- a/src/Recipes/01_Simple.cs
+++ b/src/Recipes/01_Simple.cs
@@ -16,7 +16,7 @@ namespace ProxyKit.Recipes
             {
                 app.RunProxy(context => context
                     .ForwardTo("http://localhost:5001")
-                    .ApplyXForwardedHeaders()
+                    .AddXForwardedHeaders()
                     .Send());
             }
         }

--- a/src/Recipes/02_Paths.cs
+++ b/src/Recipes/02_Paths.cs
@@ -18,14 +18,14 @@ namespace ProxyKit.Recipes
                     "/app1",
                     context => context
                         .ForwardTo("http://localhost:5001/foo/")
-                        .ApplyXForwardedHeaders()
+                        .AddXForwardedHeaders()
                         .Send());
 
                 app.RunProxy(
                     "/app2",
                     context => context
                         .ForwardTo("http://localhost:5002/bar/")
-                        .ApplyXForwardedHeaders()
+                        .AddXForwardedHeaders()
                         .Send());
             }
         }

--- a/src/Recipes/02_Paths.cs
+++ b/src/Recipes/02_Paths.cs
@@ -19,14 +19,14 @@ namespace ProxyKit.Recipes
                     context => context
                         .ForwardTo("http://localhost:5001/foo/")
                         .ApplyXForwardedHeaders()
-                        .Execute());
+                        .Send());
 
                 app.RunProxy(
                     "/app2",
                     context => context
                         .ForwardTo("http://localhost:5002/bar/")
                         .ApplyXForwardedHeaders()
-                        .Execute());
+                        .Send());
             }
         }
     }

--- a/src/Recipes/03_TenantRouting.cs
+++ b/src/Recipes/03_TenantRouting.cs
@@ -34,7 +34,7 @@ namespace ProxyKit.Recipes
 
                         return context
                             .ForwardTo($"http://{tenantId}.internal:5001")
-                            .Execute();
+                            .Send();
                     });
             }
         }

--- a/src/Recipes/04_IdSrv.cs
+++ b/src/Recipes/04_IdSrv.cs
@@ -79,7 +79,7 @@ namespace ProxyKit.Recipes
                     context => context
                         .ForwardTo(_appConfiguration.ForwardUrl)
                         .ApplyXForwardedHeaders()
-                        .Execute());
+                        .Send());
             }
         }
 

--- a/src/Recipes/04_IdSrv.cs
+++ b/src/Recipes/04_IdSrv.cs
@@ -78,7 +78,7 @@ namespace ProxyKit.Recipes
                 app.RunProxy(
                     context => context
                         .ForwardTo(_appConfiguration.ForwardUrl)
-                        .ApplyXForwardedHeaders()
+                        .AddXForwardedHeaders()
                         .Send());
             }
         }

--- a/src/Recipes/05_RoundRobin.cs
+++ b/src/Recipes/05_RoundRobin.cs
@@ -31,7 +31,7 @@ namespace ProxyKit.Recipes
 
                         var response = await context
                             .ForwardTo(host)
-                            .ApplyXForwardedHeaders()
+                            .AddXForwardedHeaders()
                             .Send();
 
                         // failover
@@ -39,7 +39,7 @@ namespace ProxyKit.Recipes
                         {
                             return await context
                                 .ForwardTo(host)
-                                .ApplyXForwardedHeaders()
+                                .AddXForwardedHeaders()
                                 .Send();
                         }
 

--- a/src/Recipes/05_RoundRobin.cs
+++ b/src/Recipes/05_RoundRobin.cs
@@ -32,7 +32,7 @@ namespace ProxyKit.Recipes
                         var response = await context
                             .ForwardTo(host)
                             .ApplyXForwardedHeaders()
-                            .Execute();
+                            .Send();
 
                         // failover
                         if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
@@ -40,7 +40,7 @@ namespace ProxyKit.Recipes
                             return await context
                                 .ForwardTo(host)
                                 .ApplyXForwardedHeaders()
-                                .Execute();
+                                .Send();
                         }
 
                         return response;

--- a/src/Recipes/06_Testing.cs
+++ b/src/Recipes/06_Testing.cs
@@ -83,7 +83,7 @@ namespace ProxyKit.Recipes
 
                         return context
                             .ForwardTo(host)
-                            .ApplyXForwardedHeaders()
+                            .AddXForwardedHeaders()
                             .Send();
                     });
             }

--- a/src/Recipes/06_Testing.cs
+++ b/src/Recipes/06_Testing.cs
@@ -84,7 +84,7 @@ namespace ProxyKit.Recipes
                         return context
                             .ForwardTo(host)
                             .ApplyXForwardedHeaders()
-                            .Execute();
+                            .Send();
                     });
             }
         }

--- a/src/Recipes/07_CustomiseUpstreamRequest.cs
+++ b/src/Recipes/07_CustomiseUpstreamRequest.cs
@@ -25,7 +25,7 @@ namespace ProxyKit.Recipes
                     {
                         forwardContext.UpstreamRequest.Headers.Add("X-Correlation-ID", Guid.NewGuid().ToString());
                     }
-                    return forwardContext.Execute();
+                    return forwardContext.Send();
                 });
 
                 // Extension Method
@@ -33,7 +33,7 @@ namespace ProxyKit.Recipes
                     .ForwardTo("http://localhost:5001")
                     .ApplyXForwardedHeaders()
                     .ApplyCorrelationId()
-                    .Execute());
+                    .Send());
             }
         }
     }

--- a/src/Recipes/07_CustomiseUpstreamRequest.cs
+++ b/src/Recipes/07_CustomiseUpstreamRequest.cs
@@ -31,7 +31,7 @@ namespace ProxyKit.Recipes
                 // Extension Method
                 app.RunProxy(context => context
                     .ForwardTo("http://localhost:5001")
-                    .ApplyXForwardedHeaders()
+                    .AddXForwardedHeaders()
                     .ApplyCorrelationId()
                     .Send());
             }

--- a/src/Recipes/08_CustomiseUpstreamResponse.cs
+++ b/src/Recipes/08_CustomiseUpstreamResponse.cs
@@ -18,7 +18,7 @@ namespace ProxyKit.Recipes
                 {
                     var response = await context
                         .ForwardTo("http://localhost:5001")
-                        .ApplyXForwardedHeaders()
+                        .AddXForwardedHeaders()
                         .Send();
 
                     response.Headers.Remove("MachineID");

--- a/src/Recipes/08_CustomiseUpstreamResponse.cs
+++ b/src/Recipes/08_CustomiseUpstreamResponse.cs
@@ -19,7 +19,7 @@ namespace ProxyKit.Recipes
                     var response = await context
                         .ForwardTo("http://localhost:5001")
                         .ApplyXForwardedHeaders()
-                        .Execute();
+                        .Send();
 
                     response.Headers.Remove("MachineID");
 

--- a/src/Recipes/09_ConsulServiceDisco.cs
+++ b/src/Recipes/09_ConsulServiceDisco.cs
@@ -24,7 +24,7 @@ namespace ProxyKit.Recipes
                     var upstreamHost = new Uri($"https://{service.Response[0].Address}:{service.Response[0].ServicePort}");
                     return await context
                         .ForwardTo(upstreamHost)
-                        .ApplyXForwardedHeaders()
+                        .AddXForwardedHeaders()
                         .Send();
                 });
 
@@ -35,7 +35,7 @@ namespace ProxyKit.Recipes
                     var upstreamHost = new Uri($"https://{service.Response[0].Address}:{service.Response[0].ServicePort}");
                     return await context
                         .ForwardTo(upstreamHost)
-                        .ApplyXForwardedHeaders()
+                        .AddXForwardedHeaders()
                         .Send();
                 });
             }

--- a/src/Recipes/09_ConsulServiceDisco.cs
+++ b/src/Recipes/09_ConsulServiceDisco.cs
@@ -25,7 +25,7 @@ namespace ProxyKit.Recipes
                     return await context
                         .ForwardTo(upstreamHost)
                         .ApplyXForwardedHeaders()
-                        .Execute();
+                        .Send();
                 });
 
                 app.RunProxy("api/bar", async context =>
@@ -36,7 +36,7 @@ namespace ProxyKit.Recipes
                     return await context
                         .ForwardTo(upstreamHost)
                         .ApplyXForwardedHeaders()
-                        .Execute();
+                        .Send();
                 });
             }
         }

--- a/src/Recipes/10_CopyXForwarded.cs
+++ b/src/Recipes/10_CopyXForwarded.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ProxyKit.Recipes
+{
+    public class CopyXForwarded : ExampleBase<CopyXForwarded.Startup>
+    {
+        public class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddProxy();
+            }
+
+            public void Configure(IApplicationBuilder app)
+            {
+                app.RunProxy(context => context
+                    .ForwardTo("http://localhost:5001")
+                    .CopyXForwardedHeaders() // copies the headers from the incoming requests
+                    .AddXForwardedHeaders() // adds the current proxy proto/host/for/pathbase to the X-Forwarded headers
+                    .Send());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #30 

Nefarious clients will send `X-Forward-*` headers as a form of attack such as spoofing the proxy to forward requests to internal hosts that shouldn't be reachable. Also some developers show debug / diagnostic things if the "host" is "localhost".

With the PR, ProxyKit no longer copies the incoming X-Forwarded-* from the incoming request. However, in chained proxy architectures, it is desirable to do that so a new extension method was added `CopyXForwardedHeaders()` allowing the developer to explicitly opt in that behaviour.

```csharp
public void Configure(IApplicationBuilder app)
{
    app.RunProxy(context => context
        .ForwardTo("http://upstream-server:5001")
        .CopyXForwardedHeaders()
        .Send());
}
```

Includes tests, docs and additional recipe.

Fixes #31 

 - Added extension method `AddXForwardedHeaders()` that will replace `ApplyXForwardedHeaders()` which has been marked as obsolete (false).

Fixes #32 

 - Added method `ForwardContext.Send()` that will replace `ForwardContext.Execute()` which has been marked as obsolete (false).