### PR TITLE
Include the host port in X-Forwarded-Host

### DIFF
--- a/src/ProxyKit.Tests/EndToEndTests.cs
+++ b/src/ProxyKit.Tests/EndToEndTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Linq;
 using System.Net;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.TestHost;
 using Shouldly;
 using Xunit;
@@ -45,6 +42,7 @@ namespace ProxyKit
                     .UseStartup<TestStartup>()))
                 {
                     var client = testServer.CreateClient();
+                    client.BaseAddress = new Uri("http://example.com:8080");
 
                     // When server is running, response code should be 'ok'
                     var result = await client.GetAsync("/realServer/normal");
@@ -120,23 +118,6 @@ namespace ProxyKit
                     Assert.Equal(HttpStatusCode.ServiceUnavailable, result.StatusCode);
                 }
             }
-        }
-    }
-
-    internal static class WebHostExtensions
-    {
-        internal static int GetServerPort(this IWebHost server)
-        {
-            var address = server.ServerFeatures.Get<IServerAddressesFeature>().Addresses.First();
-            var match = Regex.Match(address, @"^.+:(\d+)$");
-            var port = 0;
-
-            if (match.Success)
-            {
-                port = int.Parse(match.Groups[1].Value);
-            }
-
-            return port;
         }
     }
 }

--- a/src/ProxyKit.Tests/ForwardedHeadersTests.cs
+++ b/src/ProxyKit.Tests/ForwardedHeadersTests.cs
@@ -23,14 +23,14 @@ namespace ProxyKit
         [Fact]
         public void Can_append_x_forwarded_headers()
         {
-            _headers.ApplyXForwardedHeaders(IPAddress.Parse("1.2.3.4"), new HostString("example.com"), "https");
+            _headers.ApplyXForwardedHeaders(IPAddress.Parse("1.2.3.4"), new HostString("example.com:8080"), "https");
 
             var forValue = _headers.GetValues(XForwardedExtensions.XForwardedFor).ToArray();
             var hostValue = _headers.GetValues(XForwardedExtensions.XForwardedHost).ToArray();
             var protoValue = _headers.GetValues(XForwardedExtensions.XForwardedProto).ToArray();
 
             forValue.ShouldBe(new [] { "1.2.3.4"} );
-            hostValue.ShouldBe(new [] { "example.com" });
+            hostValue.ShouldBe(new [] { "example.com:8080" });
             protoValue.ShouldBe(new [] { "https" });
         }
 

--- a/src/ProxyKit.Tests/RealStartup.cs
+++ b/src/ProxyKit.Tests/RealStartup.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace ProxyKit
@@ -11,6 +12,11 @@ namespace ProxyKit
 
         public void Configure(IApplicationBuilder app)
         {
+            var options = new ForwardedHeadersOptions();
+            options.AllowedHosts.Add("*");
+            options.ForwardedHeaders = ForwardedHeaders.All;
+            app.UseXForwardedHeaders(options);
+
             app.Map("/normal", a => a.Run(async ctx =>
             {
                 ctx.Response.StatusCode = 200;

--- a/src/ProxyKit.Tests/TestStartup.cs
+++ b/src/ProxyKit.Tests/TestStartup.cs
@@ -39,6 +39,7 @@ namespace ProxyKit
                 app.Map("/realServer", appInner =>
                     appInner.RunProxy(context => context
                         .ForwardTo("http://localhost:" + port + "/")
+                        .AddXForwardedHeaders()
                         .Send()));
             }
         }

--- a/src/ProxyKit.Tests/WebHostExtensions.cs
+++ b/src/ProxyKit.Tests/WebHostExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+
+namespace ProxyKit
+{
+    internal static class WebHostExtensions
+    {
+        internal static int GetServerPort(this IWebHost server)
+        {
+            var address = server.ServerFeatures.Get<IServerAddressesFeature>().Addresses.First();
+            var match = Regex.Match(address, @"^.+:(\d+)$");
+            var port = 0;
+
+            if (match.Success)
+            {
+                port = int.Parse(match.Groups[1].Value);
+            }
+
+            return port;
+        }
+    }
+}

--- a/src/ProxyKit/XForwardedExtensions.cs
+++ b/src/ProxyKit/XForwardedExtensions.cs
@@ -56,7 +56,7 @@ namespace ProxyKit
 
             if (host.HasValue)
             {
-                outgoingHeaders.Add(XForwardedHost, host.Host);
+                outgoingHeaders.Add(XForwardedHost, host.Value);
             }
 
             if (!string.IsNullOrWhiteSpace(proto))


### PR DESCRIPTION
The port will be included in all cases. There appears to be no specification that says that it MUST be omitted if it's the same standard port as indicated by `X-Forwarded-Proto` even though some examples do that.

Fixes #43 
