### PR TITLE
Workaround for handling malformed User-Agent header

### DIFF
--- a/src/ProxyKit.Tests/ProxyKit.Tests.csproj
+++ b/src/ProxyKit.Tests/ProxyKit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RootNamespace>ProxyKit</RootNamespace>
   </PropertyGroup>
 

--- a/src/ProxyKit/HttpContextExtensions.cs
+++ b/src/ProxyKit/HttpContextExtensions.cs
@@ -32,6 +32,19 @@ namespace ProxyKit
                 }
             }
 
+            // HACK: Attempting to send a malformed User-Agent will throw from with HttpClient
+            // Remove when .net core 3 is released. Consider supporting netcoreapp2.x with #ifdef
+            // https://github.com/damianh/ProxyKit/issues/53
+            // https://github.com/dotnet/corefx/issues/34933
+            try
+            {
+                requestMessage.Headers.TryGetValues("User-Agent", out var _);
+            }
+            catch (IndexOutOfRangeException)
+            {
+                requestMessage.Headers.Remove("User-Agent");
+            }
+
             requestMessage.Method = new HttpMethod(request.Method);
 
             return requestMessage;


### PR DESCRIPTION
Bug in HttpClient / CoreFX is throwing when attempting to send a request with a malformed User-Agent header even though it was successfully added to the headers collection without validation. 

This workaround attempts to read the header and if it throws, it removes it.

Hope to revert with .net core 3.0

Fixes #53 . Works around https://github.com/dotnet/corefx/issues/34933 