### PR TITLE
WebSockets support

### DIFF
--- a/src/ProxyKit.Tests/CacheCowTests.cs
+++ b/src/ProxyKit.Tests/CacheCowTests.cs
@@ -18,7 +18,7 @@ namespace ProxyKit
         [Fact]
         public async Task Should_return_cached_item()
         {
-            using (var server = TestStartup.BuildKestrelBasedServerOnRandomPort())
+            using (var server = RealStartup.BuildKestrelBasedServerOnRandomPort())
             {
                 await server.StartAsync();
                 var port = server.GetServerPort();
@@ -30,19 +30,19 @@ namespace ProxyKit
                 {
                     var client = testServer.CreateClient();
 
-                    var response = await client.GetAsync("/realServer/normal");
+                    var response = await client.GetAsync("/realserver/normal");
                     response.Headers
                         .GetValues("x-cachecow-client")
                         .Single()
                         .ShouldContain("not-cacheable=true;did-not-exist=true");
 
-                    response = await client.GetAsync("/realServer/cachable");
+                    response = await client.GetAsync("/realserver/cachable");
                     response.Headers
                         .GetValues("x-cachecow-client")
                         .Single()
                         .ShouldContain("did-not-exist=true");
 
-                    response = await client.GetAsync("/realServer/cachable");
+                    response = await client.GetAsync("/realserver/cachable");
                     response.Headers
                         .GetValues("x-cachecow-client")
                         .Single()
@@ -83,7 +83,7 @@ namespace ProxyKit
                 var port = _config.GetValue("Port", 0);
                 if (port != 0)
                 {
-                    app.Map("/realServer", appInner =>
+                    app.Map("/realserver", appInner =>
                         appInner.RunProxy(context => context
                             .ForwardTo("http://localhost:" + port + "/")
                             .Send()));

--- a/src/ProxyKit.Tests/EndToEndTests.cs
+++ b/src/ProxyKit.Tests/EndToEndTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
@@ -31,7 +32,7 @@ namespace ProxyKit
         [Fact]
         public async Task Responses_from_real_server_are_handled_correctly()
         {
-            using (var server = TestStartup.BuildKestrelBasedServerOnRandomPort())
+            using (var server = RealStartup.BuildKestrelBasedServerOnRandomPort())
             {
                 await server.StartAsync();
                 var port = server.GetServerPort();
@@ -45,30 +46,30 @@ namespace ProxyKit
                     client.BaseAddress = new Uri("http://example.com:8080");
 
                     // When server is running, response code should be 'ok'
-                    var result = await client.GetAsync("/realServer/normal");
+                    var result = await client.GetAsync("/realserver/normal");
                     result.StatusCode.ShouldBe(HttpStatusCode.OK);
 
                     // error status codes should just be proxied
-                    result = await client.GetAsync("/realServer/badrequest");
+                    result = await client.GetAsync("/realserver/badrequest");
                     result.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
-                    result = await client.GetAsync("/realServer/error");
+                    result = await client.GetAsync("/realserver/error");
                     result.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
 
                     // server timeouts should be returned as gateway timeouts
-                    result = await client.GetAsync("/realServer/slow");
+                    result = await client.GetAsync("/realserver/slow");
                     result.StatusCode.ShouldBe(HttpStatusCode.GatewayTimeout);
 
                     // server timeouts should be 'delayed' 
                     using (var cts = new CancellationTokenSource())
                     {
                         cts.CancelAfter(TimeSpan.FromMilliseconds(1000));
-                        result = await client.GetAsync("/realServer/slow", cts.Token);
+                        result = await client.GetAsync("/realserver/slow", cts.Token);
                         result.StatusCode.ShouldBe(HttpStatusCode.GatewayTimeout);
                     }
 
                     // When server is stopped, should return 
                     await server.StopAsync();
-                    result = await client.GetAsync("/realServer/normal");
+                    result = await client.GetAsync("/realserver/normal");
                     result?.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
                 }
             }
@@ -77,7 +78,7 @@ namespace ProxyKit
         [Fact]
         public async Task When_upstream_host_is_not_running_then_should_get_service_unavailable()
         {
-            using (var server = TestStartup.BuildKestrelBasedServerOnRandomPort())
+            using (var server = RealStartup.BuildKestrelBasedServerOnRandomPort())
             {
                 await server.StartAsync();
                 var port = server.GetServerPort();
@@ -88,12 +89,12 @@ namespace ProxyKit
                 {
                     var client = testServer.CreateClient();
                     // When server is running, response code should be 'ok'
-                    var result = await client.GetAsync("/realServer/normal");
+                    var result = await client.GetAsync("/realserver/normal");
                     Assert.Equal(result.StatusCode, HttpStatusCode.OK);
 
                     // When server is stopped, should return ServiceUnavailable.
                     await server.StopAsync();
-                    result = await client.GetAsync("/realServer/normal");
+                    result = await client.GetAsync("/realserver/normal");
                     Assert.Equal(HttpStatusCode.ServiceUnavailable, result.StatusCode);
                 }
             }
@@ -102,7 +103,7 @@ namespace ProxyKit
         [Fact]
         public async Task When_upstream_host_is_not_running_and_timeout_is_small_then_operation_cancelled_is_service_unavailable()
         {
-            using (var server = TestStartup.BuildKestrelBasedServerOnRandomPort())
+            using (var server = RealStartup.BuildKestrelBasedServerOnRandomPort())
             {
                 await server.StartAsync();
                 var port = server.GetServerPort();
@@ -114,8 +115,28 @@ namespace ProxyKit
                 {
                     var client = testServer.CreateClient();
                     await server.StopAsync();
-                    var result = await client.GetAsync("/realServer/normal");
+                    var result = await client.GetAsync("/realserver/normal");
                     Assert.Equal(HttpStatusCode.ServiceUnavailable, result.StatusCode);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Can_proxy_websockets()
+        {
+            using (var server = RealStartup.BuildKestrelBasedServerOnRandomPort())
+            {
+                await server.StartAsync();
+                var port = server.GetServerPort();
+
+                using (var testServer = new TestServer(new WebHostBuilder()
+                    .UseSetting("port", port.ToString())
+                    .UseSetting("timeout", "1")
+                    .UseStartup<TestStartup>()))
+                {
+                    var client = testServer.CreateWebSocketClient();
+                    var webSocket = await client.ConnectAsync(new Uri("ws://localhost/ws"), CancellationToken.None);
+                    await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Close", CancellationToken.None);
                 }
             }
         }

--- a/src/ProxyKit.Tests/ProxyKit.Tests.csproj
+++ b/src/ProxyKit.Tests/ProxyKit.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CacheCow.Client" Version="2.4.3" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/src/ProxyKit.Tests/RealStartup.cs
+++ b/src/ProxyKit.Tests/RealStartup.cs
@@ -80,7 +80,7 @@ namespace ProxyKit
                 .Build();
         }
 
-        private async Task Echo(HttpContext context, WebSocket webSocket)
+        private async Task Echo(HttpContext _, WebSocket webSocket)
         {
             var buffer = new byte[1024 * 4];
             var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);

--- a/src/ProxyKit.Tests/RealStartup.cs
+++ b/src/ProxyKit.Tests/RealStartup.cs
@@ -1,5 +1,9 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
@@ -48,6 +52,45 @@ namespace ProxyKit
                 ctx.Response.StatusCode = 500;
                 await ctx.Response.WriteAsync("cute..... BUT IT'S WRONG!");
             }));
+
+            app.Map("/ws", a =>
+            {
+                app.UseWebSockets();
+                app.Use(async (context, next) =>
+                {
+                    if (context.WebSockets.IsWebSocketRequest)
+                    {
+                        var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+                        await Echo(context, webSocket);
+                    }
+                    else
+                    {
+                        context.Response.StatusCode = 400;
+                    }
+                });
+            });
+        }
+
+        public static IWebHost BuildKestrelBasedServerOnRandomPort()
+        {
+            return new WebHostBuilder()
+                .UseKestrel()
+                .UseUrls("http://*:0")
+                .UseStartup<RealStartup>()
+                .Build();
+        }
+
+        private async Task Echo(HttpContext context, WebSocket webSocket)
+        {
+            var buffer = new byte[1024 * 4];
+            var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+            while (!result.CloseStatus.HasValue)
+            {
+                await webSocket.SendAsync(new ArraySegment<byte>(buffer, 0, result.Count), result.MessageType, result.EndOfMessage, CancellationToken.None);
+
+                result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+            }
+            await webSocket.CloseAsync(result.CloseStatus.Value, result.CloseStatusDescription, CancellationToken.None);
         }
     }
 }

--- a/src/ProxyKit.Tests/TestStartup.cs
+++ b/src/ProxyKit.Tests/TestStartup.cs
@@ -2,7 +2,6 @@
 using System.Net;
 using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -12,7 +11,10 @@ namespace ProxyKit
     {
         private readonly IConfiguration _config;
 
-        public TestStartup(IConfiguration config) { _config = config; }
+        public TestStartup(IConfiguration config)
+        {
+            _config = config;
+        }
 
         public void ConfigureServices(IServiceCollection services)
         {
@@ -41,6 +43,11 @@ namespace ProxyKit
                         .ForwardTo("http://localhost:" + port + "/")
                         .AddXForwardedHeaders()
                         .Send()));
+
+                app.Map("/ws", appInner =>
+                {
+                    appInner.UseWebSocketProxy(new Uri($"ws://localhost:{port}/ws/"));
+                });
             }
         }
     }

--- a/src/ProxyKit.Tests/TestStartup.cs
+++ b/src/ProxyKit.Tests/TestStartup.cs
@@ -43,14 +43,5 @@ namespace ProxyKit
                         .Send()));
             }
         }
-
-        public static IWebHost BuildKestrelBasedServerOnRandomPort()
-        {
-            return new WebHostBuilder()
-                .UseKestrel()
-                .UseUrls("http://*:0")
-                .UseStartup<RealStartup>()
-                .Build();
-        }
     }
 }

--- a/src/ProxyKit.Tests/TestStartup.cs
+++ b/src/ProxyKit.Tests/TestStartup.cs
@@ -36,7 +36,7 @@ namespace ProxyKit
             var port = _config.GetValue("Port", 0);
             if (port != 0)
             {
-                app.Map("/realServer", appInner =>
+                app.Map("/realserver", appInner =>
                     appInner.RunProxy(context => context
                         .ForwardTo("http://localhost:" + port + "/")
                         .AddXForwardedHeaders()

--- a/src/ProxyKit/ApplicationBuilderExtensions.cs
+++ b/src/ProxyKit/ApplicationBuilderExtensions.cs
@@ -57,6 +57,18 @@ namespace ProxyKit
             });
         }
 
+
+        /// <summary>
+        ///     Adds WebSocket proxy that forwards websocket connections
+        ///     to destination Uri.
+        /// </summary>
+        /// <param name="app">
+        ///     The application builder.
+        /// </param>
+        /// <param name="destinationUri">
+        ///     The uri to forward the websocket connection to. Must start with
+        ///     ws:// or wss://
+        /// </param>
         public static void UseWebSocketProxy(
             this IApplicationBuilder app,
             Uri destinationUri)

--- a/src/ProxyKit/ApplicationBuilderExtensions.cs
+++ b/src/ProxyKit/ApplicationBuilderExtensions.cs
@@ -24,12 +24,7 @@ namespace ProxyKit
                 throw new ArgumentNullException(nameof(app));
             }
 
-            var proxyOptions = new ProxyOptions
-            {
-                HandleProxyRequest = handleProxyRequest,
-            };
-
-            app.UseMiddleware<ProxyMiddleware>(proxyOptions);
+            app.UseMiddleware<ProxyMiddleware>(handleProxyRequest);
         }
 
         /// <summary>
@@ -56,15 +51,27 @@ namespace ProxyKit
                 throw new ArgumentNullException(nameof(app));
             }
 
-            var proxyOptions = new ProxyOptions
-            {
-                HandleProxyRequest = handleProxyRequest,
-            };
-
             app.Map(pathMatch, appInner =>
             {
-                appInner.UseMiddleware<ProxyMiddleware>(proxyOptions);
+                appInner.UseMiddleware<ProxyMiddleware>(handleProxyRequest);
             });
+        }
+
+        public static void UseWebSocketProxy(
+            this IApplicationBuilder app,
+            Uri destinationUri)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (destinationUri == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            app.UseMiddleware<WebSocketProxyMiddleware>(destinationUri);
         }
     }
 }

--- a/src/ProxyKit/ProxyMiddleware.cs
+++ b/src/ProxyKit/ProxyMiddleware.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -8,22 +9,19 @@ using Microsoft.AspNetCore.Http;
 
 namespace ProxyKit
 {
-    /// <summary>
-    /// Proxy Middleware
-    /// </summary>
     public class ProxyMiddleware
     {
-        private readonly ProxyOptions _proxyOptions;
+        private readonly HandleProxyRequest _handleProxyRequest;
         private const int StreamCopyBufferSize = 81920;
 
-        public ProxyMiddleware(RequestDelegate _, ProxyOptions proxyOptions)
+        public ProxyMiddleware(RequestDelegate _, HandleProxyRequest handleProxyRequest)
         {
-            _proxyOptions = proxyOptions;
+            _handleProxyRequest = handleProxyRequest;
         }
 
         public async Task Invoke(HttpContext context)
         {
-            using (var response = await _proxyOptions.HandleProxyRequest(context))
+            using (var response = await _handleProxyRequest(context))
             {
                 await CopyProxyHttpResponse(context, response);
             }

--- a/src/ProxyKit/ProxyOptions.cs
+++ b/src/ProxyKit/ProxyOptions.cs
@@ -1,7 +1,11 @@
+using System;
+
 namespace ProxyKit
 {
     public class ProxyOptions
     {
-        public HandleProxyRequest HandleProxyRequest { get; set; }
+        public TimeSpan? WebSocketKeepAliveInterval { get; set; }
+
+        public int? WebSocketBufferSize { get; set; }
     }
 }

--- a/src/ProxyKit/ServiceCollectionExtensions.cs
+++ b/src/ProxyKit/ServiceCollectionExtensions.cs
@@ -8,7 +8,8 @@ namespace ProxyKit
     {
         public static IServiceCollection AddProxy(
             this IServiceCollection services,
-            Action<IHttpClientBuilder> configureHttpClientBuilder = null)
+            Action<IHttpClientBuilder> configureHttpClientBuilder = null,
+            Action<ProxyOptions> configureOptions = null)
         {
             if (services == null)
             {
@@ -17,10 +18,17 @@ namespace ProxyKit
 
             var httpClientBuilder = services
                 .AddHttpClient<ProxyKitClient>()
-                .ConfigurePrimaryHttpMessageHandler(sp => new HttpClientHandler { AllowAutoRedirect = false, UseCookies = false });
+                .ConfigurePrimaryHttpMessageHandler(sp => new HttpClientHandler
+                {
+                    AllowAutoRedirect = false,
+                    UseCookies = false
+                });
 
             configureHttpClientBuilder?.Invoke(httpClientBuilder);
 
+            configureOptions = configureOptions ?? (_ => { });
+            services.Configure(configureOptions);
+            services.AddTransient<ProxyOptions>();
             return services;
         }
     }

--- a/src/ProxyKit/WebSocketProxyMiddleware.cs
+++ b/src/ProxyKit/WebSocketProxyMiddleware.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace ProxyKit
+{
+    public class WebSocketProxyMiddleware
+    {
+        private static readonly HashSet<string> NotForwardedWebSocketHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Connection", "Host", "Upgrade", "Sec-WebSocket-Accept",
+            "Sec-WebSocket-Protocol", "Sec-WebSocket-Key", "Sec-WebSocket-Version",
+            "Sec-WebSocket-Extensions"
+        };
+        private const int DefaultWebSocketBufferSize = 4096;
+        private readonly RequestDelegate _next;
+        private readonly ProxyOptions _options;
+        private readonly Uri _destinationUri;
+        private readonly ILogger<WebSocketProxyMiddleware> _logger;
+
+        public WebSocketProxyMiddleware(
+            RequestDelegate next,
+            ProxyOptions options,
+            Uri destinationUri,
+            ILogger<WebSocketProxyMiddleware> logger)
+        {
+            _next = next;
+            _options = options;
+            _destinationUri = destinationUri;
+            _logger = logger;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            if (context.WebSockets.IsWebSocketRequest)
+            {
+                await AcceptProxyWebSocketRequest(context, _destinationUri);
+            }
+            else
+            {
+                await _next(context);
+            }
+        }
+
+        private async Task AcceptProxyWebSocketRequest(HttpContext context, Uri destinationUri)
+        {
+            using (var client = new ClientWebSocket())
+            {
+                foreach (var protocol in context.WebSockets.WebSocketRequestedProtocols)
+                {
+                    client.Options.AddSubProtocol(protocol);
+                }
+
+                foreach (var headerEntry in context.Request.Headers)
+                {
+                    if (!NotForwardedWebSocketHeaders.Contains(headerEntry.Key))
+                    {
+                        client.Options.SetRequestHeader(headerEntry.Key, headerEntry.Value);
+                    }
+                }
+
+                if (_options.WebSocketKeepAliveInterval.HasValue)
+                {
+                    client.Options.KeepAliveInterval = _options.WebSocketKeepAliveInterval.Value;
+                }
+
+                try
+                {
+                    await client.ConnectAsync(destinationUri, context.RequestAborted);
+                }
+                catch (WebSocketException ex)
+                {
+                    context.Response.StatusCode = 400;
+                    _logger.LogError(ex, "Error connecting to server");
+                    return;
+                }
+
+                using (var server = await context.WebSockets.AcceptWebSocketAsync(client.SubProtocol))
+                {
+                    var bufferSize = _options.WebSocketBufferSize ?? DefaultWebSocketBufferSize;
+                    await Task.WhenAll(
+                        PumpWebSocket(client, server, bufferSize, context.RequestAborted),
+                        PumpWebSocket(server, client, bufferSize, context.RequestAborted));
+                }
+            }
+        }
+
+        private static async Task PumpWebSocket(WebSocket source, WebSocket destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            if (bufferSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bufferSize));
+            }
+
+            var buffer = new byte[bufferSize];
+            while (true)
+            {
+                WebSocketReceiveResult result;
+                try
+                {
+                    result = await source.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    await destination.CloseOutputAsync(
+                        WebSocketCloseStatus.EndpointUnavailable,
+                        "Endpoind unavailable",
+                        cancellationToken);
+                    return;
+                }
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    await destination.CloseOutputAsync(source.CloseStatus.Value, source.CloseStatusDescription, cancellationToken);
+                    return;
+                }
+                await destination.SendAsync(
+                    new ArraySegment<byte>(buffer, 0, result.Count),
+                    result.MessageType,
+                    result.EndOfMessage,
+                    cancellationToken);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds support for websocket proxying.

Usage looks like

```csharp
app.UseWebSocketProxy(new Uri($"ws://upstream:port/"));
```

Unfortunately, because TestServer contains it's own `WebSocketClient` and doesn't use the real `ClientWebSocket`, there isn't a story for embedded testing via the router.