### PR TITLE
avoid pack warnings

### DIFF
--- a/src/ProxyKit/ProxyKit.csproj
+++ b/src/ProxyKit/ProxyKit.csproj
@@ -7,7 +7,7 @@
     <PackageId>ProxyKit</PackageId>
     <Authors>Damian Hickey</Authors>
     <PackageProjectUrl>https://github.com/damianh/ProxyKit</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/damianh/ProxyKit/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -16,7 +16,7 @@
     <TRAVIS_BUILD_NUMBER Condition="'$(TRAVIS_BUILD_NUMBER)' == ''">0</TRAVIS_BUILD_NUMBER>
     <MinVerBuildMetadata>build.$(TRAVIS_BUILD_NUMBER)</MinVerBuildMetadata>
     <PackageTags>aspnetcore;proxy;http</PackageTags>
-    <NoWarn>1701;1702;1705;1591</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;1701;1702;1705;1591</NoWarn>
     <LangVersion>latest</LangVersion>
     <DebugType>full</DebugType>
     <PackageIconUrl>https://raw.githubusercontent.com/damianh/ProxyKit/master/logo.png</PackageIconUrl>


### PR DESCRIPTION
Gets rid of

> C:\Program Files\dotnet\sdk\2.2.104\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(202,5): warning NU5105: The package version '2.0.5-alpha.0.9+build.0' uses SemVer 2.0.0 or components of SemVer 1.0.0 that are not supported on legacy clients. Change the package version to a SemVer 1.0.0 string. If the version contains a release label it must start with a letter. This message can be ignored if the package is not intended for older clients.

and

> C:\Program Files\dotnet\sdk\2.2.104\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(202,5): warning NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead.