### PR TITLE
Add Path and QueryString to WebSocket Proxy

### DIFF
--- a/src/ProxyKit/WebSocketProxyMiddleware.cs
+++ b/src/ProxyKit/WebSocketProxyMiddleware.cs
@@ -73,7 +73,8 @@ namespace ProxyKit
 
                 try
                 {
-                    await client.ConnectAsync(upstreamUri, context.RequestAborted).ConfigureAwait(false);
+                    var uriBuilder = new UriBuilder(upstreamUri.Scheme, upstreamUri.Host, upstreamUri.Port, context.Request.Path, context.Request.QueryString.Value);
+                    await client.ConnectAsync(uriBuilder.Uri, context.RequestAborted).ConfigureAwait(false);
                 }
                 catch (WebSocketException ex)
                 {


### PR DESCRIPTION
I am passing QueryString parameters to SignalR. To be consistent with the HTTP proxy middleware, i'm also passing the hub path to the proxy while only specifying the scheme, host and port in `UseWebSocketProxy`.