### PR TITLE
Add support for setting X-Forwarded-Headers on websocket client.

### DIFF
--- a/src/ProxyKit.Tests/TestStartup.cs
+++ b/src/ProxyKit.Tests/TestStartup.cs
@@ -48,14 +48,16 @@ namespace ProxyKit
                 app.UseWebSockets();
                 app.Map("/ws", appInner =>
                 {
-                    appInner.UseWebSocketProxy(_ => new Uri($"ws://localhost:{port}/ws/"));
+                    appInner.UseWebSocketProxy(
+                        _ => new Uri($"ws://localhost:{port}/ws/"),
+                        options => options.AddXForwardedHeaders());
                 });
 
                 app.Map("/ws-custom", appInner =>
                 {
                     appInner.UseWebSocketProxy(
                         _ => new Uri($"ws://localhost:{port}/ws-custom/"),
-                        webSocketClientOptions => webSocketClientOptions.SetRequestHeader("X-TraceId", "123"));
+                        options => options.SetRequestHeader("X-TraceId", "123"));
                 });
             }
         }

--- a/src/ProxyKit/ApplicationBuilderExtensions.cs
+++ b/src/ProxyKit/ApplicationBuilderExtensions.cs
@@ -78,7 +78,7 @@ namespace ProxyKit
         /// </param>
         public static void UseWebSocketProxy(
             this IApplicationBuilder app, 
-            Func<HttpContext, Uri> getUpstreamUri)
+            Func<HttpContext, UpstreamHost> getUpstreamUri)
         {
             if (app == null)
             {
@@ -105,14 +105,14 @@ namespace ProxyKit
         ///     A function to get the uri to forward the websocket connection to. The
         ///     result of which must start with ws:// or wss://
         /// </param>
-        /// <param name="customizeWebSocketClient">
+        /// <param name="configureClientOptions">
         ///     An action to allow customizing of the websocket client before initial
         ///     connection allowing you to set custom headers or adjust cookies.
         /// </param>
         public static void UseWebSocketProxy(
             this IApplicationBuilder app,
-            Func<HttpContext, Uri> getUpstreamUri,
-            Action<WebSocketClientOptions> customizeWebSocketClient)
+            Func<HttpContext, UpstreamHost> getUpstreamUri,
+            Action<WebSocketClientOptions> configureClientOptions)
         {
             if (app == null)
             {
@@ -124,7 +124,7 @@ namespace ProxyKit
                 throw new ArgumentNullException(nameof(app));
             }
 
-            app.UseMiddleware<WebSocketProxyMiddleware>(getUpstreamUri, customizeWebSocketClient);
+            app.UseMiddleware<WebSocketProxyMiddleware>(getUpstreamUri, configureClientOptions);
         }
     }
 }

--- a/src/ProxyKit/UpstreamHost.cs
+++ b/src/ProxyKit/UpstreamHost.cs
@@ -23,6 +23,7 @@ namespace ProxyKit
             Host = host;
             PathBase = pathBase;
             Weight = weight;
+            Uri = GetUri();
         }
 
         public UpstreamHost(
@@ -38,6 +39,31 @@ namespace ProxyKit
             Host = HostString.FromUriComponent(upstreamUri);
             PathBase = PathString.FromUriComponent(upstreamUri);
             Weight = weight;
+            Uri = GetUri();
+        }
+
+        private Uri GetUri()
+        {
+            var port = Host.Port ?? DefaultPort(Scheme);
+            var builder = new UriBuilder(Scheme, Host.Host, port, PathBase.Value);
+            return builder.Uri;
+        }
+
+        private int DefaultPort(string scheme)
+        {
+            switch (scheme.ToLower())
+            {
+                case "http":
+                    return 80;
+                case "https":
+                    return 443;
+                case "ws":
+                    return 80;
+                case "wss":
+                    return 443;
+                default:
+                    throw new NotSupportedException();
+            }
         }
 
         public string Scheme { get; }
@@ -47,6 +73,8 @@ namespace ProxyKit
         public PathString PathBase { get; }
 
         public uint Weight { get; }
+
+        public Uri Uri { get; }
 
         public override string ToString()
         {

--- a/src/ProxyKit/WebSocketClientOptions.cs
+++ b/src/ProxyKit/WebSocketClientOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Net.WebSockets;
+using Microsoft.AspNetCore.Http;
 
 namespace ProxyKit
 {
@@ -7,9 +8,12 @@ namespace ProxyKit
     {
         private readonly ClientWebSocketOptions _options;
 
-        internal WebSocketClientOptions(ClientWebSocketOptions options)
+        internal WebSocketClientOptions(
+            ClientWebSocketOptions options,
+            HttpContext httpContext)
         {
             _options = options;
+            HttpContext = httpContext;
         }
 
         /// <summary>
@@ -20,6 +24,11 @@ namespace ProxyKit
             get => _options.Cookies;
             set => _options.Cookies = value;
         }
+
+        /// <summary>
+        ///     The incoming HttpContext.
+        /// </summary>
+        public HttpContext HttpContext { get; }
 
         /// <summary>
         ///     Set a header on the upstream websocket request.

--- a/src/ProxyKit/WebSocketClientOptionsExtensions.cs
+++ b/src/ProxyKit/WebSocketClientOptionsExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace ProxyKit
+{
+    public static class WebSocketClientOptionsExtensions
+    {
+        /// <summary>
+        ///     Adds X-Forwarded-* headers to the upstream websocket request
+        ///     with an additional PathBase parameter.
+        /// </summary>
+        public static void AddXForwardedHeaders(this WebSocketClientOptions options)
+        {
+            var protocol = options.HttpContext.Request.Scheme;
+            var @for = options.HttpContext.Connection.RemoteIpAddress;
+            var host = options.HttpContext.Request.Headers["Host"];
+            var hostString = HostString.FromUriComponent(host);
+            var pathBase = options.HttpContext.Request.PathBase.Value;
+
+            options.AddXForwardedHeaders(@for, hostString, protocol, pathBase);
+        }
+    }
+}

--- a/src/ProxyKit/XForwardedExtensions.cs
+++ b/src/ProxyKit/XForwardedExtensions.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Sockets;
+using System.Net.WebSockets;
 using Microsoft.AspNetCore.Http;
 
 namespace ProxyKit
@@ -29,7 +30,7 @@ namespace ProxyKit
             => ApplyXForwardedHeaders(outgoingHeaders, @for, host, proto, string.Empty);
 
         /// <summary>
-        ///     Applies X-Forwarded.* headers to the outgoing header collection
+        ///     Applies X-Forwarded-* headers to the outgoing header collection
         ///     with an additional PathBase parameter.
         /// </summary>
         /// <param name="outgoingHeaders">The outgoing HTTP request
@@ -67,6 +68,37 @@ namespace ProxyKit
             if (!string.IsNullOrWhiteSpace(pathBase))
             {
                 outgoingHeaders.Add(XForwardedPathBase, pathBase);
+            }
+        }
+
+        internal static void AddXForwardedHeaders(
+            this WebSocketClientOptions options,
+            IPAddress @for,
+            HostString host,
+            string proto,
+            PathString pathBase)
+        {
+            if (@for != null)
+            {
+                var forString = @for.AddressFamily == AddressFamily.InterNetworkV6
+                    ? $"\"[{@for}]\""
+                    : @for.ToString();
+                options.SetRequestHeader(XForwardedFor, forString);
+            }
+
+            if (host.HasValue)
+            {
+                options.SetRequestHeader(XForwardedHost, host.Value);
+            }
+
+            if (!string.IsNullOrWhiteSpace(proto))
+            {
+                options.SetRequestHeader(XForwardedProto, proto);
+            }
+
+            if (!string.IsNullOrWhiteSpace(pathBase))
+            {
+                options.SetRequestHeader(XForwardedPathBase, pathBase);
             }
         }
     }

--- a/src/Recipes/15_WebSockets.cs
+++ b/src/Recipes/15_WebSockets.cs
@@ -19,7 +19,9 @@ namespace ProxyKit.Recipes
                 app.UseWebSockets();
 
                 // websockets proxy is non-terminating
-                app.UseWebSocketProxy(context => new Uri("ws://upstream-host:80"));
+                app.UseWebSocketProxy(
+                    context => new Uri("ws://upstream-host:80"),
+                    options => options.AddXForwardedHeaders());
             }
         }
     }

--- a/src/Recipes/15_WebSockets.cs
+++ b/src/Recipes/15_WebSockets.cs
@@ -21,6 +21,7 @@ namespace ProxyKit.Recipes
                 // websockets proxy is non-terminating
                 app.UseWebSocketProxy(
                     context => new Uri("ws://upstream-host:80"),
+                    // optionally add X-ForwardedHeaders to websocket client.
                     options => options.AddXForwardedHeaders());
             }
         }


### PR DESCRIPTION
Also use UpStreamHost instead of plain Uri when setting which host to forward websocket requests to.

Fixes #59