### PR TITLE
Reproduce of issue #111

### DIFF
--- a/src/ProxyKit/WebSocketProxyMiddleware.cs
+++ b/src/ProxyKit/WebSocketProxyMiddleware.cs
@@ -78,6 +78,7 @@ namespace ProxyKit
         private Task ProxyOutToWebSocket(HttpContext context)
         {
             var relativePath = context.Request.Path.ToString();
+            //var relativePath = context.Request.Path.ToString().TrimStart('/');
             var upstreamUri = _getUpstreamHost(context);
             var uriWithPath = new Uri(
                 upstreamUri.Uri,

--- a/src/SignalRSimpleChat/Pages/Index.cshtml
+++ b/src/SignalRSimpleChat/Pages/Index.cshtml
@@ -38,7 +38,8 @@
 <script>
     
     const connection = new signalR.HubConnectionBuilder()
-        .withUrl("/chat")
+        .withUrl("chat")
+        .configureLogging(signalR.LogLevel.Debug)
         .build();
 
     connection.start().catch(err => console.error(err.toString()));

--- a/src/SignalRSimpleChat/ProxyStartup.cs
+++ b/src/SignalRSimpleChat/ProxyStartup.cs
@@ -18,11 +18,14 @@ namespace ProxyKit.Recipe.SignalRSimpleChat
 
             // SignalR, as part of it's protocol, needs both http and ws traffic
             // to be forwarded to the servers hosting signalr hubs.
-            app.UseWebSocketProxy(context => new Uri("ws://localhost:5001"));
-            app.RunProxy(context => context
-                .ForwardTo("http://localhost:5001")
+            app.Map("/subpath", appInner =>
+            {
+                appInner.UseWebSocketProxy(context => new Uri("ws://localhost:5001/subpath/"));
+                appInner.RunProxy(context => context
+                    .ForwardTo("http://localhost:5001/subpath/")
                 .AddXForwardedHeaders()
-                .Send());
+                    .Send());
+            });
         }
     }
 }

--- a/src/SignalRSimpleChat/SignalRChatStartup.cs
+++ b/src/SignalRSimpleChat/SignalRChatStartup.cs
@@ -21,15 +21,20 @@ namespace ProxyKit.Recipe.SignalRSimpleChat
         }
 
         public void Configure(IApplicationBuilder app)
-        {         
-            app.UseStaticFiles();
+        {
+            //app.UsePathBase("/subpath");
 
-            app.UseSignalR(routes =>
+            app.Map("/subpath", appInner =>
             {
-                routes.MapHub<Chat>("/chat");
-            });
+                appInner.UseStaticFiles();
 
-            app.UseMvcWithDefaultRoute();
+                appInner.UseSignalR(routes =>
+                {
+                    routes.MapHub<Chat>("/chat");
+                });
+
+                appInner.UseMvcWithDefaultRoute();
+            });
         }
     }
 }


### PR DESCRIPTION
Run SignalRSimpleChat, open http://localhost:5001/subpath/ with F12, no error log in Console output. Open http://localhost:5000/subpath/ with F12, Console output shows WebSockets fail, fallback to LongPooling. Uncomment the change in WebSocketProxyMiddleware.cs fixes.