### PR TITLE
Allows specifing a proxy by using a typed handler as an alternative to the delegate.

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -3,11 +3,6 @@ workflow "Build and Test on push" {
   resolves = ["Build and Test"]
 }
 
-workflow "PR Build and Test" {
-  on = "pull_request"
-  resolves = ["Build and Test"]
-}
-
 action "Build and Test" {
   uses = "Azure/github-actions/dotnetcore-cli@master"
   args = "run --project build"

--- a/src/ProxyKit.Tests/EndToEndTests.cs
+++ b/src/ProxyKit.Tests/EndToEndTests.cs
@@ -49,6 +49,8 @@ namespace ProxyKit
                     // When server is running, response code should be 'ok'
                     var result = await client.GetAsync("/realserver/normal");
                     result.StatusCode.ShouldBe(HttpStatusCode.OK);
+                    var resultTypedHandler = await client.GetAsync("/realserver-typedhandler/normal");
+                    resultTypedHandler.StatusCode.ShouldBe(HttpStatusCode.OK);
 
                     // error status codes should just be proxied
                     result = await client.GetAsync("/realserver/badrequest");

--- a/src/ProxyKit/IProxyHandler.cs
+++ b/src/ProxyKit/IProxyHandler.cs
@@ -1,0 +1,24 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace ProxyKit
+{
+    /// <summary>
+    ///     Exposes a handler which supports forwarding a request to an upstream host.
+    /// </summary>
+    public interface IProxyHandler
+    {
+        /// <summary>
+        ///     Represents a delegate that handles a proxy request.
+        /// </summary>
+        /// <param name="context">
+        ///     An HttpContext that represents the incoming proxy request.
+        /// </param>
+        /// <returns>
+        ///     A <see cref="HttpResponseMessage"/> that represents
+        ///    the result of handling the proxy request.
+        /// </returns>
+        Task<HttpResponseMessage> HandleProxyRequest(HttpContext context);
+    }
+}

--- a/src/ProxyKit/ProxyMiddleware.cs
+++ b/src/ProxyKit/ProxyMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -9,19 +8,19 @@ using Microsoft.AspNetCore.Http;
 
 namespace ProxyKit
 {
-    public class ProxyMiddleware
+    public class ProxyMiddleware<TProxyHandler> where TProxyHandler:IProxyHandler
     {
-        private readonly HandleProxyRequest _handleProxyRequest;
+        private readonly TProxyHandler _handler;
         private const int StreamCopyBufferSize = 81920;
 
-        public ProxyMiddleware(RequestDelegate _, HandleProxyRequest handleProxyRequest)
+        public ProxyMiddleware(RequestDelegate _, TProxyHandler handler)
         {
-            _handleProxyRequest = handleProxyRequest;
+            _handler = handler;
         }
 
         public async Task Invoke(HttpContext context)
         {
-            using (var response = await _handleProxyRequest(context).ConfigureAwait(false))
+            using (var response = await _handler.HandleProxyRequest(context).ConfigureAwait(false))
             {
                 await CopyProxyHttpResponse(context, response).ConfigureAwait(false);
             }

--- a/src/SignalRSimpleChat/SignalRChatStartup.cs
+++ b/src/SignalRSimpleChat/SignalRChatStartup.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace ProxyKit.Recipe.SignalRSimpleChat
 {
-    public class SignalRChatStartup
+    public class SignalRChatStartup 
     {
         public SignalRChatStartup(IConfiguration configuration)
         {


### PR DESCRIPTION
Allows one to specify a proxy configuration via a typed handler allowing easier dependency injection scenarios.

```csharp
app.UseProxy<FooTypedHandler>();
```

Note that dependency injection only occurs when the middleware is activated. To get a request level scope service, one still needs to go to `context.RequestService`.

cc @ben-foster-cko