### PR TITLE
Added factory activated ProxyMiddleware

### DIFF
--- a/src/ProxyKit/ApplicationBuilderExtensions.cs
+++ b/src/ProxyKit/ApplicationBuilderExtensions.cs
@@ -31,7 +31,7 @@ namespace ProxyKit
                 throw new ArgumentNullException(nameof(handleProxyRequest));
             }
 
-            app.UseMiddleware<ProxyMiddleware<HandleProxyRequestWrapper>>(new HandleProxyRequestWrapper(handleProxyRequest));
+            app.UseMiddleware<ConventionalProxyMiddleware<HandleProxyRequestWrapper>>(new HandleProxyRequestWrapper(handleProxyRequest));
         }
 
 
@@ -49,7 +49,7 @@ namespace ProxyKit
                 throw new ArgumentNullException(nameof(app));
             }
 
-            app.UseMiddleware<ProxyMiddleware<TProxyHandler>>();
+            app.UseMiddleware<ConventionalProxyMiddleware<TProxyHandler>>();
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace ProxyKit
 
             app.Map(pathMatch, appInner =>
             {
-                appInner.UseMiddleware<ProxyMiddleware<HandleProxyRequestWrapper>>(new HandleProxyRequestWrapper(handleProxyRequest));
+                appInner.UseMiddleware<ConventionalProxyMiddleware<HandleProxyRequestWrapper>>(new HandleProxyRequestWrapper(handleProxyRequest));
             });
         }
 

--- a/src/ProxyKit/ConventionalProxyMiddleware.cs
+++ b/src/ProxyKit/ConventionalProxyMiddleware.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace ProxyKit
+{
+    public class ConventionalProxyMiddleware<TProxyHandler> : ProxyMiddleware
+        where TProxyHandler:IProxyHandler
+    {
+        private readonly TProxyHandler _handler;
+
+        public ConventionalProxyMiddleware(RequestDelegate _, TProxyHandler handler)
+        {
+            _handler = handler;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            using (var response = await _handler.HandleProxyRequest(context).ConfigureAwait(false))
+            {
+                await CopyProxyHttpResponse(context, response).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/ProxyKit/FactoryActivatedProxyMiddleware.cs
+++ b/src/ProxyKit/FactoryActivatedProxyMiddleware.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace ProxyKit
+{
+    public class FactoryActivatedProxyMiddleware<TProxyHandler> : ProxyMiddleware, IMiddleware
+        where TProxyHandler : IProxyHandler
+    {
+        private readonly TProxyHandler _handler;
+
+        public FactoryActivatedProxyMiddleware(TProxyHandler handler)
+        {
+            _handler = handler;
+        }
+        
+        public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+        {
+            using (var response = await _handler.HandleProxyRequest(context).ConfigureAwait(false))
+            {
+                await CopyProxyHttpResponse(context, response).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/ProxyKit/ProxyMiddleware.cs
+++ b/src/ProxyKit/ProxyMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -9,25 +8,11 @@ using Microsoft.AspNetCore.Http;
 
 namespace ProxyKit
 {
-    public class ProxyMiddleware<TProxyHandler> where TProxyHandler:IProxyHandler
+    public abstract class ProxyMiddleware
     {
-        private readonly TProxyHandler _handler;
         private const int StreamCopyBufferSize = 81920;
 
-        public ProxyMiddleware(RequestDelegate _, TProxyHandler handler)
-        {
-            _handler = handler;
-        }
-
-        public async Task Invoke(HttpContext context)
-        {
-            using (var response = await _handler.HandleProxyRequest(context).ConfigureAwait(false))
-            {
-                await CopyProxyHttpResponse(context, response).ConfigureAwait(false);
-            }
-        }
-
-        private static async Task CopyProxyHttpResponse(HttpContext context, HttpResponseMessage responseMessage)
+        protected static async Task CopyProxyHttpResponse(HttpContext context, HttpResponseMessage responseMessage)
         {
             var response = context.Response;
 


### PR DESCRIPTION
I am using SimpleInjector and needed the ProxyMiddleware to implement IMiddleware. Added this by creating a base class and two implementations, one factory activated and the other a conventional one.

https://docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware/extensibility?view=aspnetcore-2.2 