### PR TITLE
ReadOnly streams shouldn't be flushed

### DIFF
--- a/src/ProxyKit/ProxyMiddleware.cs
+++ b/src/ProxyKit/ProxyMiddleware.cs
@@ -53,7 +53,10 @@ namespace ProxyKit
                 using (var responseStream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false))
                 {
                     await responseStream.CopyToAsync(response.Body, StreamCopyBufferSize, context.RequestAborted).ConfigureAwait(false);
-                    await responseStream.FlushAsync(context.RequestAborted).ConfigureAwait(false);
+                    if (responseStream.CanWrite)
+                    {
+                        await responseStream.FlushAsync(context.RequestAborted).ConfigureAwait(false);    
+                    }
                 }
             }
         }


### PR DESCRIPTION
I observed the behavior that [ProxyMiddleware flushes every stream](https://github.com/damianh/ProxyKit/blob/master/src/ProxyKit/ProxyMiddleware.cs#L56) without having a look if it is read-only or not. 

So, sometimes AspnetCore TestsHost creates read-only streams as the response for FOUND verbs I don't know exactly when but, after upgrading ProxyKit the latest version [this change](https://github.com/damianh/ProxyKit/commit/7c893970448ff519f9f520fa2d1ce7f0287ff9c8#diff-bf059ff7bcbac62b87c51b955d0e8e7c) led to the problem and I got `The stream does not support writing.
   at System.Net.Http.StreamContent.ReadOnlyStream.FlushAsync(CancellationToken cancellationToken)` exception, since it is read-only.

This change will address the issue. 