### PR TITLE
Support for AspNetCore 3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+**/bin/
+**/obj/
+**/global.json
+**/Dockerfile*
+**/.dockerignore*
+**/*.user
+**/*.Custom.json
+**/*.CustomDotSettings
+.idea/
+.vs/
+.vscode/
+.git/
+**/node_modules
+artifacts/
+**/_NCrunch_*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 mono: none
 sudo: false
 dist: xenial
-dotnet: 2.2
+dotnet: 3.0
 script: "./build.sh --travis"
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: csharp
 mono: none
 sudo: false
 dist: xenial
-dotnet: 3.0
+services:
+  - docker
 script: "./build.sh --travis"
 git:
   depth: false

--- a/build-local.cmd
+++ b/build-local.cmd
@@ -1,0 +1,2 @@
+@echo Off
+dotnet run --project build -- %*

--- a/build-local.sh
+++ b/build-local.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+dotnet run --project build -- "$@"

--- a/build.cmd
+++ b/build.cmd
@@ -11,7 +11,7 @@ if errorlevel 1 (
 
 docker run --rm --name proxykit-build ^
  -v %cd%/artifacts:/repo/artifacts ^
- -v %cd%/.git:/.git ^
+ -v %cd%/.git:/repo/.git ^
  -e MYGET_API_KEY=$MYGET_API_KEY ^
  proxykit-build ^
  dotnet run -p /repo/build/build.csproj -c Release -- %*

--- a/build.cmd
+++ b/build.cmd
@@ -12,6 +12,7 @@ if errorlevel 1 (
 docker run --rm --name proxykit-build ^
  -v %cd%/artifacts:/repo/artifacts ^
  -v %cd%/.git:/.git ^
+ -e MYGET_API_KEY=$MYGET_API_KEY ^
  proxykit-build ^
  dotnet run -p /repo/build/build.csproj -c Release -- %*
 

--- a/build.cmd
+++ b/build.cmd
@@ -1,2 +1,21 @@
-@echo Off
-dotnet run --project build -- %*
+@ECHO OFF
+
+docker build ^
+ -f build.Dockerfile ^
+ --tag proxykit-build .
+
+if errorlevel 1 (
+   echo Docker build failed: Exit code is %errorlevel%
+   exit /b %errorlevel%
+)
+
+docker run --rm --name proxykit-build ^
+ -v %cd%/artifacts:/repo/artifacts ^
+ -v %cd%/.git:/.git ^
+ proxykit-build ^
+ dotnet run -p /repo/build/build.csproj -c Release -- %*
+
+if errorlevel 1 (
+   echo Docker build failed: Exit code is %errorlevel%
+   exit /b %errorlevel%
+)

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -1,4 +1,6 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.0.100-alpine3.9
+ARG MYGET_API_KEY
+ENV MYGET_API_KEY=${MYGET_API_KEY}
 
 # Install DotNet Core 2.1
 RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.802/dotnet-sdk-2.1.802-linux-musl-x64.tar.gz \

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0.100-alpine3.9 AS build
+
+# Install Dotnet core 2.1 too
+RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.802/dotnet-sdk-2.1.802-linux-musl-x64.tar.gz \
+    && dotnet_sha512='69fac356dd7ee7445e640326a6eedfe95d93d901437fdb6f30de80cb23274ea645cf172d656e72e5a11be5ebd8022a8d9ef7931e5de59d7521331fcbf51b7c15' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm dotnet.tar.gz
+
+WORKDIR /repo
+

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -8,5 +8,22 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
     && rm dotnet.tar.gz
 
+RUN apk add git=2.20.1-r0
+
 WORKDIR /repo
 
+# Copy slns, csprojs and do a dotnet restore
+COPY ./build/*.sln ./build/
+COPY ./build/*.csproj ./build/
+WORKDIR /repo/build
+RUN dotnet restore
+
+WORKDIR /repo
+COPY ./*.sln ./
+COPY ./src/*/*.csproj ./src/
+RUN for file in $(ls src/*.csproj); do mkdir -p ./${file%.*}/ && mv $file ./${file%.*}/; done
+RUN dotnet restore
+
+# Copy source files
+COPY ./build ./build/
+COPY ./src ./src/

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -1,12 +1,11 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.0.100-alpine3.9 AS build
 
-# Install Dotnet core 2.1 too
+# Install DotNet Core 2.1
 RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.802/dotnet-sdk-2.1.802-linux-musl-x64.tar.gz \
     && dotnet_sha512='69fac356dd7ee7445e640326a6eedfe95d93d901437fdb6f30de80cb23274ea645cf172d656e72e5a11be5ebd8022a8d9ef7931e5de59d7521331fcbf51b7c15' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz
 
 WORKDIR /repo

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -1,6 +1,4 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.0.100-alpine3.9
-ARG MYGET_API_KEY
-ENV MYGET_API_KEY=${MYGET_API_KEY}
 
 # Install DotNet Core 2.1
 RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.802/dotnet-sdk-2.1.802-linux-musl-x64.tar.gz \

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0.100-alpine3.9 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0.100-alpine3.9
 
 # Install DotNet Core 2.1
 RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.802/dotnet-sdk-2.1.802-linux-musl-x64.tar.gz \

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@ docker build \
  --tag proxykit-build .
 
 docker run --rm --name proxykit-build \
+ --build-arg MYGET_API_KEY=$MYGET_API_KEY \
  -v $PWD/artifacts:/repo/artifacts \
  -v $PWD/.git:/repo/.git \
  proxykit-build \

--- a/build.sh
+++ b/build.sh
@@ -6,8 +6,8 @@ docker build \
  --tag proxykit-build .
 
 docker run --rm --name proxykit-build \
- --build-arg MYGET_API_KEY=$MYGET_API_KEY \
  -v $PWD/artifacts:/repo/artifacts \
  -v $PWD/.git:/repo/.git \
+ -e MYGET_API_KEY=$MYGET_API_KEY \
  proxykit-build \
  dotnet run -p /repo/build/build.csproj -c Release -- "$@"

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 docker build \
+ --build-arg MYGET_API_KEY=$MYGET_API_KEY \
  -f build.dockerfile \
  --tag proxykit-build .
 

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,11 @@
 #!/usr/bin/env bash
-set -euo pipefail
-dotnet run --project build -- "$@"
+
+docker build \
+ -f build.dockerfile \
+ --tag proxykit-build .
+
+docker run --rm --name proxykit-build \
+ -v $PWD/artifacts:/repo/artifacts \
+ -v $PWD/.git:/repo/.git \
+ proxykit-build \
+ dotnet run -p /repo/build/build.csproj -c Release -- "$@"

--- a/src/Paths/Paths.csproj
+++ b/src/Paths/Paths.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <AssemblyName>ProxyKit.Recipe.Simple</AssemblyName>
     <RootNamespace>ProxyKit.Recipe.Simple</RootNamespace>
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ProxyKit.Tests/CacheCowTests.cs
+++ b/src/ProxyKit.Tests/CacheCowTests.cs
@@ -10,15 +10,23 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace ProxyKit
 {
     public class CacheCowTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public CacheCowTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         [Fact]
         public async Task Should_return_cached_item()
         {
-            using (var server = RealStartup.BuildKestrelBasedServerOnRandomPort())
+            using (var server = RealStartup.BuildKestrelBasedServerOnRandomPort(_testOutputHelper))
             {
                 await server.StartAsync();
                 var port = server.GetServerPort();

--- a/src/ProxyKit.Tests/EndToEndTests.cs
+++ b/src/ProxyKit.Tests/EndToEndTests.cs
@@ -40,7 +40,7 @@ namespace ProxyKit
 
                 using (var testServer = new TestServer(new WebHostBuilder()
                     .UseSetting("port", port.ToString())
-                    .UseSetting("timeout", "4")
+                    .UseSetting("timeout", "2") // 2 seconds
                     .UseStartup<ProxyStartup>()))
                 {
                     var client = testServer.CreateClient();
@@ -58,14 +58,10 @@ namespace ProxyKit
                     result = await client.GetAsync("/realserver/error");
                     result.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
 
-                    // server timeouts should be returned as gateway timeouts
-                    result = await client.GetAsync("/realserver/slow");
-                    result.StatusCode.ShouldBe(HttpStatusCode.GatewayTimeout);
-
-                    // server timeouts should be 'delayed' 
+                    // server timeouts should return GatewayTimeout 
                     using (var cts = new CancellationTokenSource())
                     {
-                        cts.CancelAfter(TimeSpan.FromMilliseconds(1000));
+                        cts.CancelAfter(TimeSpan.FromSeconds(4)); // should be longer than timeout
                         result = await client.GetAsync("/realserver/slow", cts.Token);
                         result.StatusCode.ShouldBe(HttpStatusCode.GatewayTimeout);
                     }

--- a/src/ProxyKit.Tests/ProxyKit.Tests.csproj
+++ b/src/ProxyKit.Tests/ProxyKit.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
@@ -8,18 +8,18 @@
 
   <ItemGroup>
     <PackageReference Include="CacheCow.Client" Version="2.4.4" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit.assert" Version="2.4.1" />
     <PackageReference Include="xunit.core" Version="2.4.1" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="1.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />

--- a/src/ProxyKit.Tests/ProxyKit.Tests.csproj
+++ b/src/ProxyKit.Tests/ProxyKit.Tests.csproj
@@ -1,17 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <RootNamespace>ProxyKit</RootNamespace>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CacheCow.Client" Version="2.4.4" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit.assert" Version="2.4.1" />
@@ -20,6 +17,17 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="1.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ProxyKit.Tests/ProxyKit.Tests.netcoreapp2.1.v3.ncrunchproject
+++ b/src/ProxyKit.Tests/ProxyKit.Tests.netcoreapp2.1.v3.ncrunchproject
@@ -1,0 +1,7 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <HiddenComponentWarnings>
+      <Value>AspNetTestHostCompatibility</Value>
+    </HiddenComponentWarnings>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ProxyKit.Tests/ProxyKit.Tests.netcoreapp3.0.v3.ncrunchproject
+++ b/src/ProxyKit.Tests/ProxyKit.Tests.netcoreapp3.0.v3.ncrunchproject
@@ -1,0 +1,7 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <HiddenComponentWarnings>
+      <Value>AspNetTestHostCompatibility</Value>
+    </HiddenComponentWarnings>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ProxyKit/ForwardContext.cs
+++ b/src/ProxyKit/ForwardContext.cs
@@ -36,17 +36,18 @@ namespace ProxyKit
         public Task<HttpResponseMessage> Execute() => Send();
 
         /// <summary>
-        /// Sends the forward request to the upstream host.
+        /// Sends the upstream request to the upstream host.
         /// </summary>
-        /// <returns>An HttpResponseMessage </returns>
+        /// <returns>An <see cref="HttpResponseMessage"/> the represents the proxy response.</returns>
         public async Task<HttpResponseMessage> Send()
         {
             try
             {
-                return await _httpClient.SendAsync(
-                    UpstreamRequest,
-                    HttpCompletionOption.ResponseHeadersRead,
-                    HttpContext.RequestAborted)
+                return await _httpClient
+                    .SendAsync(
+                        UpstreamRequest,
+                        HttpCompletionOption.ResponseHeadersRead,
+                        HttpContext.RequestAborted)
                     .ConfigureAwait(false);
             }
             catch (TaskCanceledException ex) when (ex.InnerException is IOException)

--- a/src/ProxyKit/ProxyKit.csproj
+++ b/src/ProxyKit/ProxyKit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <Description>An AspNet core middleware toolkit to create proxy servers. Can be embedded in applications or used as a standalone proxy.</Description>
     <PackageId>ProxyKit</PackageId>
     <Authors>Damian Hickey</Authors>
@@ -20,21 +20,28 @@
     <DebugType>full</DebugType>
     <PackageIconUrl>https://raw.githubusercontent.com/damianh/ProxyKit/master/logo.png</PackageIconUrl>
     <PackageReleaseNotes>See https://github.com/damianh/ProxyKit/releases for release notes.</PackageReleaseNotes>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 </Project>

--- a/src/ProxyKit/ProxyKit.csproj
+++ b/src/ProxyKit/ProxyKit.csproj
@@ -28,7 +28,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="1.2.0">
+    <PackageReference Include="MinVer" Version="2.0.0-rc.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Recipes/Recipes.csproj
+++ b/src/Recipes/Recipes.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>Recipes</AssemblyName>
     <RootNamespace>ProxyKit.Recipes</RootNamespace>
     <LangVersion>latest</LangVersion>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +14,7 @@
     <PackageReference Include="EasyConsoleStd" Version="2.0.0" />
     <PackageReference Include="IPNetwork2" Version="2.4.0.147" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SignalRSimpleChat/SignalRSimpleChat.csproj
+++ b/src/SignalRSimpleChat/SignalRSimpleChat.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>ProxyKit.Recipe.SignalRSimpleChat</AssemblyName>
     <RootNamespace>ProxyKit.Recipe.SignalRSimpleChat</RootNamespace>
   </PropertyGroup>

--- a/src/Simple/Simple.csproj
+++ b/src/Simple/Simple.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <AssemblyName>ProxyKit.Recipe.Simple</AssemblyName>
     <RootNamespace>ProxyKit.Recipe.Simple</RootNamespace>
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TenantForwarding/TenantForwarding.csproj
+++ b/src/TenantForwarding/TenantForwarding.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <AssemblyName>ProxyKit.Recipe.Simple</AssemblyName>
     <RootNamespace>ProxyKit.Recipe.Simple</RootNamespace>
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="idunno.Authentication.Basic" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Multi-target main lib as netstandard2.0 and netcoreapp3.0
- Use conditional ItemGroup references so netcoreapp3.0 can use FrameworkReference and netstandard can use nuget packages
- Multi-target test lib as netcoreapp2.1 and netcoreapp3.0
- Test lib use newer version of SignalR