### PR TITLE
Update the buildnumber action version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Generate build number
-      uses: einaregilsson/build-number@v1 
+      uses: einaregilsson/build-number@v2
       with:
         token: ${{secrets.github_token}}
     - name: Build and Test


### PR DESCRIPTION
Hopefully fixes this error:
##[error]Failed to create new build-number ref. Status: 403, err: null, result: {"message":"Resource not accessible by integration","documentation_url":"https://developer.github.com/v3/git/refs/#create-a-reference"}