### PR TITLE
CI workflow for CI, PR workflow for PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,11 +1,7 @@
-name: CI
+name: PR
 
 on:
-  push:
-    branches:
-    - master
-    tags:
-    - v*
+  pull_request:
 
 jobs:
   build:
@@ -16,10 +12,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v1
-    - name: Generate build number
-      uses: einaregilsson/build-number@v2
-      with:
-        token: ${{secrets.github_token}}
     - name: Build and Test
       run: bash build.sh
       shell: bash


### PR DESCRIPTION
PRs don't try to generate a build number because of permissions required by the action.