### PR TITLE
Handling muliple cookie headers

### DIFF
--- a/src/ProxyKit.Tests/AcceptanceTestsBase.cs
+++ b/src/ProxyKit.Tests/AcceptanceTestsBase.cs
@@ -47,7 +47,7 @@ namespace ProxyKit
 
         protected abstract int ProxyPort { get; }
 
-        protected abstract HttpClient CreateClient();
+        protected abstract HttpClient CreateClient(bool useCookies = true);
 
         protected CookieContainer CookieContainer { get; } = new CookieContainer();
 
@@ -73,6 +73,21 @@ namespace ProxyKit
             
             var response = await client.GetAsync("/cookie-count");
             
+            var body = await response.Content.ReadAsStringAsync();
+            body.ShouldBe("2");
+        }
+
+
+        [Fact]
+        public async Task Can_handle_cookies_on_multiple_headers()
+        {
+            var client = CreateClient(false);
+            var request = new HttpRequestMessage(HttpMethod.Get, "/cookie-count");
+            request.Headers.TryAddWithoutValidation("Cookie", "yummy_cookie=choco");
+            request.Headers.TryAddWithoutValidation("Cookie", "tasty_cookie=strawberry");
+
+            var response = await client.SendAsync(request);
+
             var body = await response.Content.ReadAsStringAsync();
             body.ShouldBe("2");
         }

--- a/src/ProxyKit.Tests/AzureTests.cs
+++ b/src/ProxyKit.Tests/AzureTests.cs
@@ -80,7 +80,7 @@ namespace ProxyKit
             {
                 // my blog is currently hosted on azure. If it move this will need to be changed.
                 app.RunProxy(context => context
-                    .ForwardTo("http://dhickey.ie")
+                    .ForwardTo("https://proxykit.azurewebsites.net")
                     .Send());
             }
         }

--- a/src/ProxyKit.Tests/KestrelServerAcceptanceTests.cs
+++ b/src/ProxyKit.Tests/KestrelServerAcceptanceTests.cs
@@ -25,11 +25,17 @@ namespace ProxyKit
 
         protected override int ProxyPort => _proxyServer.GetServerPort();
 
-        protected override HttpClient CreateClient() =>
-            new HttpClient
+        protected override HttpClient CreateClient()
+        {
+            var handler = new HttpClientHandler
+            {
+                CookieContainer = CookieContainer
+            };
+            return new HttpClient(handler)
             {
                 BaseAddress = new Uri($"http://localhost:{ProxyPort}")
             };
+        }
 
         [Fact]
         public async Task When_upstream_host_is_not_running_then_should_get_service_unavailable()

--- a/src/ProxyKit.Tests/KestrelServerAcceptanceTests.cs
+++ b/src/ProxyKit.Tests/KestrelServerAcceptanceTests.cs
@@ -25,11 +25,12 @@ namespace ProxyKit
 
         protected override int ProxyPort => _proxyServer.GetServerPort();
 
-        protected override HttpClient CreateClient()
+        protected override HttpClient CreateClient(bool useCookies = true)
         {
             var handler = new HttpClientHandler
             {
-                CookieContainer = CookieContainer
+                CookieContainer = CookieContainer,
+                UseCookies = useCookies,
             };
             return new HttpClient(handler)
             {

--- a/src/ProxyKit.Tests/TestServerAcceptanceTests.cs
+++ b/src/ProxyKit.Tests/TestServerAcceptanceTests.cs
@@ -1,8 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Net.Http.Headers;
 using ProxyKit.RoutingHandler;
 using Xunit.Abstractions;
 
@@ -22,8 +28,11 @@ namespace ProxyKit
 
         protected override HttpClient CreateClient()
         {
-            var client = _proxyTestServer.CreateClient();
-            client.BaseAddress = new Uri($"http://localhost:{_proxyPort}/");
+            var handler = new CookieHandler(_proxyTestServer.CreateHandler(), CookieContainer);
+            var client = new HttpClient(handler)
+            {
+                BaseAddress = new Uri($"http://localhost:{_proxyPort}/")
+            };
             return client;
         }
 
@@ -56,6 +65,40 @@ namespace ProxyKit
             _upstreamTestServer.Dispose();
             _proxyTestServer.Dispose();
             return Task.CompletedTask;
+        }
+
+        public class CookieHandler : DelegatingHandler
+        {
+            private readonly CookieContainer _cookieContainer;
+
+            public CookieHandler(HttpMessageHandler innerHandler, CookieContainer cookieContainer)
+                : base(innerHandler)
+            {
+                _cookieContainer = cookieContainer;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            {
+                var requestUri = request.RequestUri;
+                request.Headers.Add(HeaderNames.Cookie, _cookieContainer.GetCookieHeader(requestUri));
+
+                var response = await base.SendAsync(request, ct);
+
+                if (response.Headers.TryGetValues(HeaderNames.SetCookie, out IEnumerable<string> setCookieHeaders))
+                {
+                    foreach (var cookieHeader in SetCookieHeaderValue.ParseList(setCookieHeaders.ToList()))
+                    {
+                        Cookie cookie = new Cookie(cookieHeader.Name.Value, cookieHeader.Value.Value, cookieHeader.Path.Value);
+                        if (cookieHeader.Expires.HasValue)
+                        {
+                            cookie.Expires = cookieHeader.Expires.Value.DateTime;
+                        }
+                        _cookieContainer.Add(requestUri, cookie);
+                    }
+                }
+
+                return response;
+            }
         }
     }
 }

--- a/src/ProxyKit.Tests/TestServerAcceptanceTests.cs
+++ b/src/ProxyKit.Tests/TestServerAcceptanceTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -26,9 +25,12 @@ namespace ProxyKit
 
         protected override int ProxyPort => _proxyPort;
 
-        protected override HttpClient CreateClient()
+        protected override HttpClient CreateClient(bool useCookies = true)
         {
-            var handler = new CookieHandler(_proxyTestServer.CreateHandler(), CookieContainer);
+            var handler = useCookies 
+                ? new CookieHandler(_proxyTestServer.CreateHandler(), CookieContainer)
+                : _proxyTestServer.CreateHandler();
+
             var client = new HttpClient(handler)
             {
                 BaseAddress = new Uri($"http://localhost:{_proxyPort}/")

--- a/src/ProxyKit/HttpContextExtensions.cs
+++ b/src/ProxyKit/HttpContextExtensions.cs
@@ -74,8 +74,9 @@ namespace ProxyKit
                 }
             }
 
+
+#if NETSTANDARD2_0
             // HACK: Attempting to send a malformed User-Agent will throw from with HttpClient
-            // Remove when .net core 3 is released. Consider supporting netcoreapp2.x with #ifdef
             // https://github.com/damianh/ProxyKit/issues/53
             // https://github.com/dotnet/corefx/issues/34933
             try
@@ -86,6 +87,7 @@ namespace ProxyKit
             {
                 requestMessage.Headers.Remove("User-Agent");
             }
+#endif
 
             requestMessage.Method = new HttpMethod(request.Method);
 


### PR DESCRIPTION
~Tests that attempt to reproduce #231 however they pass.~

Ported the fix from yarp. https://github.com/microsoft/reverse-proxy/pull/451/